### PR TITLE
fix: rollback to properly set `s.LastHeightValidatorsChanged`

### DIFF
--- a/state/execution.go
+++ b/state/execution.go
@@ -292,6 +292,7 @@ func (blockExec *BlockExecutor) applyBlock(state State, blockID types.BlockID, b
 		state.Validators = state.NextValidators.Copy()
 		state.NextValidators.IncrementProposerPriority(1)
 
+		// save the new validator set
 		blockExec.store.SaveValidators(state.LastBlockHeight+1, state.LastHeightValidatorsChanged, state.Validators)
 	}
 

--- a/state/mocks/store.go
+++ b/state/mocks/store.go
@@ -154,37 +154,6 @@ func (_m *Store) LoadConsensusParams(_a0 int64) (types.ConsensusParams, error) {
 	return r0, r1
 }
 
-// LoadConsensusParamsWithLastHeightChanged provides a mock function with given fields: _a0
-func (_m *Store) LoadConsensusParamsWithLastHeightChanged(_a0 int64) (types.ConsensusParams, int64, error) {
-	ret := _m.Called(_a0)
-
-	var r0 types.ConsensusParams
-	var r1 int64
-	var r2 error
-	if rf, ok := ret.Get(0).(func(int64) (types.ConsensusParams, int64, error)); ok {
-		return rf(_a0)
-	}
-	if rf, ok := ret.Get(0).(func(int64) types.ConsensusParams); ok {
-		r0 = rf(_a0)
-	} else {
-		r0 = ret.Get(0).(types.ConsensusParams)
-	}
-
-	if rf, ok := ret.Get(1).(func(int64) int64); ok {
-		r1 = rf(_a0)
-	} else {
-		r1 = ret.Get(1).(int64)
-	}
-
-	if rf, ok := ret.Get(2).(func(int64) error); ok {
-		r2 = rf(_a0)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
-}
-
 // LoadFinalizeBlockResponse provides a mock function with given fields: _a0
 func (_m *Store) LoadFinalizeBlockResponse(_a0 int64) (*abcitypes.ResponseFinalizeBlock, error) {
 	ret := _m.Called(_a0)
@@ -285,6 +254,54 @@ func (_m *Store) LoadLastFinalizeBlockResponse(_a0 int64) (*abcitypes.ResponseFi
 	return r0, r1
 }
 
+// LoadLastHeightConsensusParamsChanged provides a mock function with given fields: _a0
+func (_m *Store) LoadLastHeightConsensusParamsChanged(_a0 int64) (int64, error) {
+	ret := _m.Called(_a0)
+
+	var r0 int64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(int64) (int64, error)); ok {
+		return rf(_a0)
+	}
+	if rf, ok := ret.Get(0).(func(int64) int64); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	if rf, ok := ret.Get(1).(func(int64) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// LoadLastHeightValidatorsChanged provides a mock function with given fields: _a0
+func (_m *Store) LoadLastHeightValidatorsChanged(_a0 int64) (int64, error) {
+	ret := _m.Called(_a0)
+
+	var r0 int64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(int64) (int64, error)); ok {
+		return rf(_a0)
+	}
+	if rf, ok := ret.Get(0).(func(int64) int64); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	if rf, ok := ret.Get(1).(func(int64) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // LoadValidators provides a mock function with given fields: _a0
 func (_m *Store) LoadValidators(_a0 int64) (*types.ValidatorSet, error) {
 	ret := _m.Called(_a0)
@@ -309,39 +326,6 @@ func (_m *Store) LoadValidators(_a0 int64) (*types.ValidatorSet, error) {
 	}
 
 	return r0, r1
-}
-
-// LoadValidatorsWithLastHeightChanged provides a mock function with given fields: _a0
-func (_m *Store) LoadValidatorsWithLastHeightChanged(_a0 int64) (*types.ValidatorSet, int64, error) {
-	ret := _m.Called(_a0)
-
-	var r0 *types.ValidatorSet
-	var r1 int64
-	var r2 error
-	if rf, ok := ret.Get(0).(func(int64) (*types.ValidatorSet, int64, error)); ok {
-		return rf(_a0)
-	}
-	if rf, ok := ret.Get(0).(func(int64) *types.ValidatorSet); ok {
-		r0 = rf(_a0)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*types.ValidatorSet)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(int64) int64); ok {
-		r1 = rf(_a0)
-	} else {
-		r1 = ret.Get(1).(int64)
-	}
-
-	if rf, ok := ret.Get(2).(func(int64) error); ok {
-		r2 = rf(_a0)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
 }
 
 // PruneStates provides a mock function with given fields: _a0, _a1, _a2

--- a/state/rollback.go
+++ b/state/rollback.go
@@ -55,9 +55,16 @@ func Rollback(bs BlockStore, ss Store, removeBlock bool) (int64, []byte, error) 
 		return -1, nil, fmt.Errorf("block at height %d not found", invalidState.LastBlockHeight)
 	}
 
-	previousLastValidatorSet, valLastHeightChanged, err := ss.LoadValidatorsWithLastHeightChanged(rollbackHeight)
+	previousLastValidatorSet, err := ss.LoadValidators(rollbackHeight)
 	if err != nil {
 		return -1, nil, err
+	}
+
+	nextHeight := rollbackHeight + 1
+	valChangeHeight := invalidState.LastHeightValidatorsChanged
+	// this can only happen if the validator set changed since the last block
+	if valChangeHeight > nextHeight+1 {
+		valChangeHeight = nextHeight + 1
 	}
 
 	previousParams, err := ss.LoadConsensusParams(rollbackHeight + 1)
@@ -91,7 +98,7 @@ func Rollback(bs BlockStore, ss Store, removeBlock bool) (int64, []byte, error) 
 		NextValidators:              invalidState.Validators,
 		Validators:                  invalidState.LastValidators,
 		LastValidators:              previousLastValidatorSet,
-		LastHeightValidatorsChanged: valLastHeightChanged,
+		LastHeightValidatorsChanged: valChangeHeight,
 
 		ConsensusParams:                  previousParams,
 		LastHeightConsensusParamsChanged: paramsChangeHeight,
@@ -118,16 +125,23 @@ func Rollback(bs BlockStore, ss Store, removeBlock bool) (int64, []byte, error) 
 	return rolledBackState.LastBlockHeight, rolledBackState.AppHash, nil
 }
 
-// MultipleRollback overwrites the current CometBFT state with the
-// previous state of the given height.
+// RollbackTo overwrites the current CometBFT state with the state at the given height.
 // Note that this function does not affect application state.
-func MultipleRollback(bs BlockStore, ss Store, rollbackHeight int64) (int64, []byte, error) {
+func RollbackTo(bs BlockStore, ss Store, rollbackHeight int64, removeBlock bool) (int64, []byte, error) {
 	invalidState, err := ss.Load()
 	if err != nil {
 		return -1, nil, err
 	}
 	if invalidState.IsEmpty() {
 		return -1, nil, errors.New("no state found")
+	}
+	if invalidState.LastBlockHeight <= rollbackHeight {
+		return -1, nil, fmt.Errorf("rollback height %d is greater than or equal to the last block height %d", rollbackHeight, invalidState.LastBlockHeight)
+	}
+
+	// rollback 1 block
+	if invalidState.LastBlockHeight == rollbackHeight+1 {
+		return Rollback(bs, ss, removeBlock)
 	}
 
 	// state store height is equal to blockstore height. We're good to proceed with rolling back state
@@ -136,30 +150,38 @@ func MultipleRollback(bs BlockStore, ss Store, rollbackHeight int64) (int64, []b
 		return -1, nil, fmt.Errorf("block at height %d not found", rollbackHeight)
 	}
 	// We also need to retrieve the next block because the app hash and last
-	// results hash is only agreed upon in the following block.
-	nextBlock := bs.LoadBlockMeta(rollbackHeight + 1)
+	// results hash is only agreed upon in the next block.
+	nextHeight := rollbackHeight + 1
+	nextBlock := bs.LoadBlockMeta(nextHeight)
 	if nextBlock == nil {
-		return -1, nil, fmt.Errorf("block at height %d not found", rollbackHeight+1)
+		return -1, nil, fmt.Errorf("block at height %d not found", nextHeight)
 	}
 
 	lastValidatorSet, err := ss.LoadValidators(rollbackHeight)
 	if err != nil {
 		return -1, nil, err
 	}
-
-	validatorSet, valLastHeightChanged, err := ss.LoadValidatorsWithLastHeightChanged(rollbackHeight + 1)
+	validatorSet, err := ss.LoadValidators(nextHeight)
 	if err != nil {
 		return -1, nil, err
 	}
-	nextValidatorSet := validatorSet.Copy()
-	nextValidatorSet.IncrementProposerPriority(1)
+	nextValidatorSet := validatorSet.CopyIncrementProposerPriority(1)
 
-	previousParams, paramsLastHeightChanged, err := ss.LoadConsensusParamsWithLastHeightChanged(rollbackHeight + 1)
+	// Note that if s.LastBlockHeight causes a valset change,
+	// we set s.LastHeightValidatorsChanged = s.LastBlockHeight + 1 + 1
+	// Extra +1 due to nextValSet delay.
+	//
+	// So we need to load LastHeightValidatorsChanged of (rollbackHeight + 1 + 1).
+	valLastHeightChanged, err := ss.LoadLastHeightValidatorsChanged(nextHeight + 1)
 	if err != nil {
 		return -1, nil, err
 	}
 
-	err = bs.DeleteBlocksFromHeight(rollbackHeight + 1)
+	previousParams, err := ss.LoadConsensusParams(nextHeight)
+	if err != nil {
+		return -1, nil, err
+	}
+	paramsLastHeightChanged, err := ss.LoadLastHeightConsensusParamsChanged(nextHeight)
 	if err != nil {
 		return -1, nil, err
 	}
@@ -192,9 +214,22 @@ func MultipleRollback(bs BlockStore, ss Store, rollbackHeight int64) (int64, []b
 		LastResultsHash: nextBlock.Header.LastResultsHash,
 	}
 
+	// persist the new state. This overrides the invalid one. NOTE: this will also
+	// persist the validator set and consensus params over the existing structures,
+	// but both should be the same
 	err = ss.Save(rolledBackState)
 	if err != nil {
 		return -1, nil, err
 	}
+
+	// If removeBlock is true then also remove the block associated with the previous state.
+	// This will mean both the last state and last block height is equal to `rollbakHeight`
+	if removeBlock {
+		err = bs.DeleteBlocksFromHeight(nextHeight)
+		if err != nil {
+			return -1, nil, err
+		}
+	}
+
 	return rolledBackState.LastBlockHeight, rolledBackState.AppHash, nil
 }

--- a/state/rollback.go
+++ b/state/rollback.go
@@ -67,6 +67,10 @@ func Rollback(bs BlockStore, ss Store, removeBlock bool) (int64, []byte, error) 
 		valChangeHeight = nextHeight + 1
 	}
 
+	if CheckExecutorChanged(previousLastValidatorSet, invalidState.LastValidators) {
+		valChangeHeight = nextHeight
+	}
+
 	previousParams, err := ss.LoadConsensusParams(rollbackHeight + 1)
 	if err != nil {
 		return -1, nil, err
@@ -175,6 +179,10 @@ func RollbackTo(bs BlockStore, ss Store, rollbackHeight int64, removeBlock bool)
 	valLastHeightChanged, err := ss.LoadLastHeightValidatorsChanged(nextHeight + 1)
 	if err != nil {
 		return -1, nil, err
+	}
+
+	if CheckExecutorChanged(lastValidatorSet, validatorSet) {
+		valLastHeightChanged = nextHeight
 	}
 
 	previousParams, err := ss.LoadConsensusParams(nextHeight)

--- a/state/rollback_test.go
+++ b/state/rollback_test.go
@@ -286,3 +286,75 @@ func makeBlockIDRandom() types.BlockID {
 		},
 	}
 }
+
+func nextState(initialState state.State) state.State {
+	nextHeight := initialState.LastBlockHeight + 1
+	newParams := types.DefaultConsensusParams()
+	newParams.Version.App = uint64(nextHeight)
+	newParams.Block.MaxBytes = 1000
+
+	nextState := initialState.Copy()
+	nextState.LastBlockHeight = nextHeight
+	nextState.Version.Consensus.App = 11
+	nextState.LastBlockID = makeBlockIDRandom()
+	nextState.AppHash = tmhash.Sum([]byte("app_hash"))
+	nextState.LastValidators = initialState.Validators
+	nextState.Validators = initialState.NextValidators
+	nextState.NextValidators = initialState.NextValidators.CopyIncrementProposerPriority(1)
+	nextState.ConsensusParams = *newParams
+	nextState.LastHeightConsensusParamsChanged = nextHeight
+	nextState.LastHeightValidatorsChanged = nextHeight + 1
+
+	return nextState
+}
+
+func TestRollback_To(t *testing.T) {
+	height := int64(100)
+	nextHeight := int64(101)
+	blockStore := &mocks.BlockStore{}
+	stateStore := setupStateStore(t, height)
+	initialState, err := stateStore.Load()
+	require.NoError(t, err)
+
+	curState := initialState
+	blockStore.On("LoadBlockMeta", height).Return(&types.BlockMeta{
+		BlockID: initialState.LastBlockID,
+		Header: types.Header{
+			Height:          initialState.LastBlockHeight,
+			Time:            initialState.LastBlockTime,
+			AppHash:         crypto.CRandBytes(tmhash.Size),
+			LastBlockID:     makeBlockIDRandom(),
+			LastResultsHash: initialState.LastResultsHash,
+		},
+	})
+
+	for range 10 {
+		curState = nextState(curState)
+		require.NoError(t, stateStore.Save(curState))
+
+		if curState.LastBlockHeight == nextHeight {
+			blockStore.On("LoadBlockMeta", nextHeight).Return(&types.BlockMeta{
+				BlockID: initialState.LastBlockID,
+				Header: types.Header{
+					Height:          initialState.LastBlockHeight,
+					Time:            initialState.LastBlockTime,
+					AppHash:         initialState.AppHash,
+					LastBlockID:     makeBlockIDRandom(),
+					LastResultsHash: initialState.LastResultsHash,
+				},
+			})
+		}
+	}
+
+	// rollback the state
+	rollbackHeight, rollbackHash, err := state.RollbackTo(blockStore, stateStore, 100, false)
+	require.NoError(t, err)
+	require.EqualValues(t, 100, rollbackHeight)
+	require.EqualValues(t, initialState.AppHash, rollbackHash)
+	blockStore.AssertExpectations(t)
+
+	// assert that we've recovered the prior state
+	loadedState, err := stateStore.Load()
+	require.NoError(t, err)
+	require.EqualValues(t, initialState, loadedState)
+}

--- a/state/rollback_test.go
+++ b/state/rollback_test.go
@@ -347,9 +347,9 @@ func TestRollback_To(t *testing.T) {
 	}
 
 	// rollback the state
-	rollbackHeight, rollbackHash, err := state.RollbackTo(blockStore, stateStore, 100, false)
+	rollbackHeight, rollbackHash, err := state.RollbackTo(blockStore, stateStore, height, false)
 	require.NoError(t, err)
-	require.EqualValues(t, 100, rollbackHeight)
+	require.EqualValues(t, height, rollbackHeight)
 	require.EqualValues(t, initialState.AppHash, rollbackHash)
 	blockStore.AssertExpectations(t)
 

--- a/state/store.go
+++ b/state/store.go
@@ -65,17 +65,16 @@ type Store interface {
 	Load() (State, error)
 	// LoadValidators loads the validator set at a given height
 	LoadValidators(int64) (*types.ValidatorSet, error)
-
-	// LoadValidatorsWithLastHeightChanged loads the validator set at a given height and the last height changed
-	LoadValidatorsWithLastHeightChanged(int64) (*types.ValidatorSet, int64, error)
+	// LoadLastHeightValidatorsChanged loads the last height at which the validators changed
+	LoadLastHeightValidatorsChanged(int64) (int64, error)
 	// LoadFinalizeBlockResponse loads the abciResponse for a given height
 	LoadFinalizeBlockResponse(int64) (*abci.ResponseFinalizeBlock, error)
 	// LoadLastFinalizeBlockResponse loads the last abciResponse for a given height
 	LoadLastFinalizeBlockResponse(int64) (*abci.ResponseFinalizeBlock, error)
 	// LoadConsensusParams loads the consensus params for a given height
 	LoadConsensusParams(int64) (types.ConsensusParams, error)
-	// LoadValidatorsWithLastHeightChanged loads the validator set at a given height and the last height changed
-	LoadConsensusParamsWithLastHeightChanged(int64) (types.ConsensusParams, int64, error)
+	// LoadLastHeightConsensusParamsChanged loads the last height at which the consensus params changed
+	LoadLastHeightConsensusParamsChanged(int64) (int64, error)
 
 	// initia custom, it is to save last rollup sync height to avoid starting sync at 1
 	GetRollupSyncBatchChainHeight(int64) (int64, error)
@@ -627,13 +626,12 @@ func (store dbStore) LoadValidators(height int64) (*types.ValidatorSet, error) {
 	return vip, nil
 }
 
-func (store dbStore) LoadValidatorsWithLastHeightChanged(height int64) (*types.ValidatorSet, int64, error) {
+func (store dbStore) LoadLastHeightValidatorsChanged(height int64) (int64, error) {
 	valInfo, err := loadValidatorsInfo(store.db, height)
 	if err != nil {
-		return nil, 0, ErrNoValSetForHeight{height}
+		return 0, ErrNoValSetForHeight{height}
 	}
-	vip, err := store.LoadValidators(height)
-	return vip, valInfo.LastHeightChanged, err
+	return valInfo.LastHeightChanged, err
 }
 
 func lastStoredHeightFor(height, lastHeightChanged int64) int64 {
@@ -731,17 +729,13 @@ func (store dbStore) LoadConsensusParams(height int64) (types.ConsensusParams, e
 	return types.ConsensusParamsFromProto(paramsInfo.ConsensusParams), nil
 }
 
-func (store dbStore) LoadConsensusParamsWithLastHeightChanged(height int64) (types.ConsensusParams, int64, error) {
-	var (
-		empty = types.ConsensusParams{}
-	)
+func (store dbStore) LoadLastHeightConsensusParamsChanged(height int64) (int64, error) {
 	paramsInfo, err := store.loadConsensusParamsInfo(height)
 	if err != nil {
-		return empty, 0, fmt.Errorf("could not find consensus params for height #%d: %w", height, err)
+		return 0, fmt.Errorf("could not find consensus params for height #%d: %w", height, err)
 	}
 
-	params, err := store.LoadConsensusParams(height)
-	return params, paramsInfo.LastHeightChanged, err
+	return paramsInfo.LastHeightChanged, err
 }
 
 func (store dbStore) loadConsensusParamsInfo(height int64) (*cmtstate.ConsensusParamsInfo, error) {


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

