### PR TITLE
feat: non-validator node keep using blocksync mode

### DIFF
--- a/blocksync/pool.go
+++ b/blocksync/pool.go
@@ -245,7 +245,7 @@ func (pool *BlockPool) PeekTwoBlocks() (first, second *types.Block, firstExtComm
 		first = r.getBlock()
 
 		// If the block is from a trusted peer, set the Trusted flag to true
-		if slices.Contains(pool.trustedPeerIDs, r.peerID) {
+		if first != nil && slices.Contains(pool.trustedPeerIDs, r.peerID) {
 			first.Trusted = true
 		}
 

--- a/blocksync/pool.go
+++ b/blocksync/pool.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 	"sync/atomic"
 	"time"
@@ -88,6 +89,8 @@ type BlockPool struct {
 
 	requestsCh chan<- BlockRequest
 	errorsCh   chan<- peerError
+
+	trustedPeerIDs []p2p.ID
 }
 
 // NewBlockPool returns a new BlockPool with the height equal to start. Block
@@ -106,6 +109,11 @@ func NewBlockPool(start int64, requestsCh chan<- BlockRequest, errorsCh chan<- p
 	}
 	bp.BaseService = *service.NewBaseService(nil, "BlockPool", bp)
 	return bp
+}
+
+// SetTrustedPeerIDs sets the list of trusted peer IDs.
+func (pool *BlockPool) SetTrustedPeerIDs(peerIDs []p2p.ID) {
+	pool.trustedPeerIDs = peerIDs
 }
 
 // OnStart implements service.Service by spawning requesters routine and recording
@@ -235,6 +243,12 @@ func (pool *BlockPool) PeekTwoBlocks() (first, second *types.Block, firstExtComm
 
 	if r := pool.requesters[pool.height]; r != nil {
 		first = r.getBlock()
+
+		// If the block is from a trusted peer, set the Trusted flag to true
+		if slices.Contains(pool.trustedPeerIDs, r.peerID) {
+			first.Trusted = true
+		}
+
 		firstExtCommit = r.getExtendedCommit()
 	}
 	if r := pool.requesters[pool.height+1]; r != nil {

--- a/blocksync/reactor.go
+++ b/blocksync/reactor.go
@@ -134,6 +134,11 @@ func (bcR *Reactor) SetExitOnInvalidBlock() {
 	bcR.exitOnInvalidBlock = true
 }
 
+// SetTrustedPeerIDs sets the list of trusted peer IDs.
+func (bcR *Reactor) SetTrustedPeerIDs(peerIDs []p2p.ID) {
+	bcR.pool.SetTrustedPeerIDs(peerIDs)
+}
+
 // SetLogger implements service.Service by setting the logger on reactor and pool.
 func (bcR *Reactor) SetLogger(l log.Logger) {
 	bcR.BaseService.Logger = l
@@ -472,7 +477,7 @@ FOR_LOOP:
 
 			// See if there are any blocks to sync.
 			first, second, extCommit := bcR.pool.PeekTwoBlocks()
-			if first == nil || second == nil {
+			if first == nil || (!first.Trusted && second == nil) {
 				// we need to have fetched two consecutive blocks in order to
 				// perform blocksync verification
 				continue FOR_LOOP
@@ -482,7 +487,7 @@ FOR_LOOP:
 				// Panicking because the block pool's height  MUST keep consistent with the state; the block pool is totally under our control
 				panic(fmt.Errorf("peeked first block has unexpected height; expected %d, got %d", state.LastBlockHeight+1, first.Height))
 			}
-			if first.Height+1 != second.Height {
+			if !first.Trusted && first.Height+1 != second.Height {
 				// Panicking because this is an obvious bug in the block pool, which is totally under our control
 				panic(fmt.Errorf("heights of first and second block are not consecutive; expected %d, got %d", state.LastBlockHeight, first.Height))
 			}
@@ -511,8 +516,10 @@ FOR_LOOP:
 			// first.Hash() doesn't verify the tx contents, so MakePartSet() is
 			// currently necessary.
 			// TODO(sergio): Should we also validate against the extended commit?
-			err = state.Validators.VerifyCommitLight(
-				chainID, firstID, first.Height, second.LastCommit)
+			if !first.Trusted {
+				err = state.Validators.VerifyCommitLight(
+					chainID, firstID, first.Height, second.LastCommit)
+			}
 
 			if err == nil {
 				// validate the block before we persist it
@@ -551,6 +558,14 @@ FOR_LOOP:
 					// still need to clean up the rest.
 					bcR.Switch.StopPeerForError(peer, ErrReactorValidation{Err: err})
 				}
+
+				// if the first block is trusted, we did not conduct any verification with the second block
+				// so we can skip the rest of the loop
+				if first.Trusted {
+					continue FOR_LOOP
+				}
+
+				// remove the second block peer and redo all its requests
 				peerID2 := bcR.pool.RemovePeerAndRedoAllPeerRequests(second.Height)
 				peer2 := bcR.Switch.Peers().Get(peerID2)
 				if peer2 != nil && peer2 != peer {
@@ -567,11 +582,19 @@ FOR_LOOP:
 			if extensionsEnabled {
 				bcR.store.SaveBlockWithExtendedCommit(first, firstParts, extCommit)
 			} else {
+				var lastCommit *types.Commit
+				if second != nil {
+					lastCommit = second.LastCommit
+				}
+
 				// We use LastCommit here instead of extCommit. extCommit is not
 				// guaranteed to be populated by the peer if extensions are not enabled.
 				// Currently, the peer should provide an extCommit even if the vote extension data are absent
 				// but this may change so using second.LastCommit is safer.
-				bcR.store.SaveBlock(first, firstParts, second.LastCommit)
+				bcR.store.SaveBlock(first, firstParts, lastCommit)
+
+				// store the last commit of the previous block
+				bcR.store.SaveSeenCommit(first.Height-1, lastCommit)
 			}
 
 			// TODO: same thing for app - but we would need a way to

--- a/blocksync/reactor.go
+++ b/blocksync/reactor.go
@@ -445,7 +445,7 @@ FOR_LOOP:
 				conR, ok := bcR.Switch.Reactor("CONSENSUS").(consensusReactor)
 				if conR != nil && !conR.IsValidator(state) {
 					// if the node is not a validator, we don't need to switch to consensus
-					bcR.Logger.Info("Not a validator, skipping switch to consensus")
+					bcR.Logger.Debug("Not a validator, skipping switch to consensus")
 					continue FOR_LOOP
 				}
 
@@ -543,11 +543,16 @@ FOR_LOOP:
 			}
 			presentExtCommit := extCommit != nil
 			extensionsEnabled := state.ConsensusParams.ABCI.VoteExtensionsEnabled(first.Height)
-			if (extensionsEnabled && !presentExtCommit) || (!extensionsEnabled && presentExtCommit && !first.Trusted) {
+			if extensionsEnabled && !presentExtCommit {
 				err = fmt.Errorf("non-nil extended commit must be received iff vote extensions are enabled for its height "+
 					"(height %d, non-nil extended commit %t, extensions enabled %t)",
 					first.Height, presentExtCommit, extensionsEnabled,
 				)
+			} else if !extensionsEnabled && presentExtCommit && !first.Trusted {
+				// if the block is not trusted and vote extensions are not enabled,
+				// ignore the custom extCommit and make it nil
+				extCommit = nil
+				presentExtCommit = false
 			}
 			if err == nil && extensionsEnabled {
 				// if vote extensions were required at this height, ensure they exist.
@@ -564,7 +569,7 @@ FOR_LOOP:
 				}
 
 				// if the first block is trusted, we did not conduct any verification with the second block
-				// so we can skip the rest of the loop
+				// so we should skip the rest of the loop
 				if first.Trusted {
 					continue FOR_LOOP
 				}

--- a/blocksync/reactor.go
+++ b/blocksync/reactor.go
@@ -594,7 +594,7 @@ FOR_LOOP:
 				bcR.store.SaveBlock(first, firstParts, lastCommit)
 
 				// store the last commit of the previous block
-				bcR.store.SaveSeenCommit(first.Height-1, lastCommit)
+				bcR.store.SaveSeenCommit(first.Height-1, first.LastCommit)
 			}
 
 			// TODO: same thing for app - but we would need a way to

--- a/blocksync/reactor.go
+++ b/blocksync/reactor.go
@@ -26,8 +26,8 @@ const (
 	// within this much of the system time.
 	// stopSyncingDurationMinutes = 10
 
-	// ask for best height every 10s
-	statusUpdateIntervalSeconds = 10
+	// ask for best height every 300ms
+	statusUpdateIntervalSeconds = 300
 	// check if we should switch to consensus reactor
 	switchToConsensusIntervalSeconds = 1
 )
@@ -333,7 +333,7 @@ func (bcR *Reactor) poolRoutine(stateSynced bool) {
 	trySyncTicker := time.NewTicker(trySyncIntervalMS * time.Millisecond)
 	defer trySyncTicker.Stop()
 
-	statusUpdateTicker := time.NewTicker(statusUpdateIntervalSeconds * time.Second)
+	statusUpdateTicker := time.NewTicker(statusUpdateIntervalSeconds * time.Millisecond)
 	defer statusUpdateTicker.Stop()
 
 	if bcR.switchToConsensusMs == 0 {

--- a/blocksync/reactor.go
+++ b/blocksync/reactor.go
@@ -247,6 +247,10 @@ func (bcR *Reactor) respondToPeer(msg *bcproto.BlockRequest, src p2p.Peer) (queu
 			bcR.Logger.Error("found block in store with no extended commit", "block", block)
 			return false
 		}
+	} else if blockCommit := bcR.store.LoadBlockCommit(msg.Height); blockCommit != nil {
+		extCommit = blockCommit.WrappedExtendedCommit()
+	} else if seenCommit := bcR.store.LoadSeenCommit(msg.Height); seenCommit != nil {
+		extCommit = seenCommit.WrappedExtendedCommit()
 	}
 
 	bl, err := block.ToProto()
@@ -585,6 +589,18 @@ FOR_LOOP:
 				var lastCommit *types.Commit
 				if second != nil {
 					lastCommit = second.LastCommit
+				} else if extCommit != nil {
+					lastCommit = extCommit.ToCommit()
+
+					vs := lastCommit.ToVoteSet(state.ChainID, state.LastValidators)
+					if !vs.HasTwoThirdsMajority() {
+						bcR.Logger.Error("received seen commits from the trusted peer, but it does not have +2/3 majority",
+							"height", first.Height)
+						continue FOR_LOOP
+					}
+				} else {
+					// this is from trusted peer, but we dont't receive extCommit
+					continue FOR_LOOP
 				}
 
 				// We use LastCommit here instead of extCommit. extCommit is not
@@ -592,9 +608,10 @@ FOR_LOOP:
 				// Currently, the peer should provide an extCommit even if the vote extension data are absent
 				// but this may change so using second.LastCommit is safer.
 				bcR.store.SaveBlock(first, firstParts, lastCommit)
-
-				// store the last commit of the previous block
-				bcR.store.SaveSeenCommit(first.Height-1, first.LastCommit)
+				err := bcR.store.SaveSeenCommit(first.Height-1, first.LastCommit)
+				if err != nil {
+					panic(err)
+				}
 			}
 
 			// TODO: same thing for app - but we would need a way to

--- a/blocksync/reactor.go
+++ b/blocksync/reactor.go
@@ -608,10 +608,6 @@ FOR_LOOP:
 				// Currently, the peer should provide an extCommit even if the vote extension data are absent
 				// but this may change so using second.LastCommit is safer.
 				bcR.store.SaveBlock(first, firstParts, lastCommit)
-				err := bcR.store.SaveSeenCommit(first.Height-1, first.LastCommit)
-				if err != nil {
-					panic(err)
-				}
 			}
 
 			// TODO: same thing for app - but we would need a way to

--- a/blocksync/reactor.go
+++ b/blocksync/reactor.go
@@ -36,6 +36,9 @@ type consensusReactor interface {
 	// for when we switch from blocksync reactor and block sync to
 	// the consensus machine
 	SwitchToConsensus(state sm.State, skipWAL bool)
+
+	// IsValidator returns true if the node is a validator
+	IsValidator(state sm.State) bool
 }
 
 type peerError struct {
@@ -430,11 +433,18 @@ FOR_LOOP:
 				continue FOR_LOOP
 			}
 			if bcR.pool.IsCaughtUp() || bcR.localNodeBlocksTheChain(state) {
+				conR, ok := bcR.Switch.Reactor("CONSENSUS").(consensusReactor)
+				if conR != nil && !conR.IsValidator(state) {
+					// if the node is not a validator, we don't need to switch to consensus
+					bcR.Logger.Info("Not a validator, skipping switch to consensus")
+					continue FOR_LOOP
+				}
+
 				bcR.Logger.Info("Time to switch to consensus reactor!", "height", height)
 				if err := bcR.pool.Stop(); err != nil {
 					bcR.Logger.Error("Error stopping pool", "err", err)
 				}
-				conR, ok := bcR.Switch.Reactor("CONSENSUS").(consensusReactor)
+
 				if ok {
 					conR.SwitchToConsensus(state, blocksSynced > 0 || stateSynced)
 				}

--- a/blocksync/reactor.go
+++ b/blocksync/reactor.go
@@ -543,7 +543,7 @@ FOR_LOOP:
 			}
 			presentExtCommit := extCommit != nil
 			extensionsEnabled := state.ConsensusParams.ABCI.VoteExtensionsEnabled(first.Height)
-			if presentExtCommit != extensionsEnabled {
+			if (extensionsEnabled && !presentExtCommit) || (!extensionsEnabled && presentExtCommit && !first.Trusted) {
 				err = fmt.Errorf("non-nil extended commit must be received iff vote extensions are enabled for its height "+
 					"(height %d, non-nil extended commit %t, extensions enabled %t)",
 					first.Height, presentExtCommit, extensionsEnabled,

--- a/blocksync/reactor.go
+++ b/blocksync/reactor.go
@@ -26,8 +26,8 @@ const (
 	// within this much of the system time.
 	// stopSyncingDurationMinutes = 10
 
-	// ask for best height every 300ms
-	statusUpdateIntervalSeconds = 300
+	// ask for best height every 250ms
+	statusUpdateIntervalMilliseconds = 250
 	// check if we should switch to consensus reactor
 	switchToConsensusIntervalSeconds = 1
 )
@@ -338,7 +338,7 @@ func (bcR *Reactor) poolRoutine(stateSynced bool) {
 	trySyncTicker := time.NewTicker(trySyncIntervalMS * time.Millisecond)
 	defer trySyncTicker.Stop()
 
-	statusUpdateTicker := time.NewTicker(statusUpdateIntervalSeconds * time.Millisecond)
+	statusUpdateTicker := time.NewTicker(statusUpdateIntervalMilliseconds * time.Millisecond)
 	defer statusUpdateTicker.Stop()
 
 	if bcR.switchToConsensusMs == 0 {

--- a/cmd/cometbft/commands/run_node.go
+++ b/cmd/cometbft/commands/run_node.go
@@ -67,6 +67,7 @@ func AddNodeFlags(cmd *cobra.Command) {
 	cmd.Flags().String("p2p.persistent_peers", config.P2P.PersistentPeers, "comma-delimited ID@host:port persistent peers")
 	cmd.Flags().String("p2p.unconditional_peer_ids",
 		config.P2P.UnconditionalPeerIDs, "comma-delimited IDs of unconditional peers")
+	cmd.Flags().String("p2p.trusted_peer_ids", config.P2P.TrustedPeerIDs, "comma-delimited IDs of trusted peers")
 	cmd.Flags().Bool("p2p.pex", config.P2P.PexReactor, "enable/disable Peer-Exchange")
 	cmd.Flags().Bool("p2p.seed_mode", config.P2P.SeedMode, "enable/disable seed mode")
 	cmd.Flags().String("p2p.private_peer_ids", config.P2P.PrivatePeerIDs, "comma-delimited private peer IDs")

--- a/config/config.go
+++ b/config/config.go
@@ -577,6 +577,9 @@ type P2PConfig struct { //nolint: maligned
 	// List of node IDs, to which a connection will be (re)established ignoring any existing limits
 	UnconditionalPeerIDs string `mapstructure:"unconditional_peer_ids"`
 
+	// Comma separated list of peer IDs to trust
+	TrustedPeerIDs string `mapstructure:"trusted_peer_ids"`
+
 	// Maximum pause when redialing a persistent peer (if zero, exponential backoff is used)
 	PersistentPeersMaxDialPeriod time.Duration `mapstructure:"persistent_peers_max_dial_period"`
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -300,6 +300,9 @@ max_num_outbound_peers = {{ .P2P.MaxNumOutboundPeers }}
 # List of node IDs, to which a connection will be (re)established ignoring any existing limits
 unconditional_peer_ids = "{{ .P2P.UnconditionalPeerIDs }}"
 
+# Comma separated list of peer IDs to trust
+trusted_peer_ids = "{{ .P2P.TrustedPeerIDs }}"
+
 # Maximum pause when redialing a persistent peer (if zero, exponential backoff is used)
 persistent_peers_max_dial_period = "{{ .P2P.PersistentPeersMaxDialPeriod }}"
 

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -102,6 +102,11 @@ func (conR *Reactor) OnStop() {
 	}
 }
 
+// IsValidator returns true if the node is a validator based on the given state
+func (conR *Reactor) IsValidator(state sm.State) bool {
+	return conR.conS.IsValidator(state)
+}
+
 // SwitchToConsensus switches from block_sync mode to consensus mode.
 // It resets the state, turns off block_sync, and starts the consensus state-machine
 func (conR *Reactor) SwitchToConsensus(state sm.State, skipWAL bool) {

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -1238,12 +1238,10 @@ func (bs *mockBlockStore) DeleteBlocksFromHeight(height int64) error { return ni
 
 func (bs *mockBlockStore) Close() error { return nil }
 
-func (bs *mockBlockStore) SaveInvalidBlock(_ string, _ int64) {
-}
+func (bs *mockBlockStore) LoadInvalidBlock() (string, int64)  { return "", 0 }
+func (bs *mockBlockStore) SaveInvalidBlock(_ string, _ int64) {}
 
-func (bs *mockBlockStore) LoadInvalidBlock() (string, int64) {
-	return "", 0
-}
+func (bs *mockBlockStore) SaveSeenCommit(height int64, seenCommit *types.Commit) error { return nil }
 
 func (bs *mockBlockStore) LoadBlockBytes(height int64) []byte {
 	return nil

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -207,6 +207,16 @@ func NewState(
 	return cs
 }
 
+// IsValidator returns true if the node is a validator based on the given state
+func (cs *State) IsValidator(state sm.State) bool {
+	pubkey := cs.privValidatorPubKey
+	if pubkey == nil {
+		return false
+	}
+
+	return state.Validators.HasAddress(pubkey.Address())
+}
+
 // SetLogger implements Service.
 func (cs *State) SetLogger(l log.Logger) {
 	cs.BaseService.Logger = l

--- a/node/setup.go
+++ b/node/setup.go
@@ -297,6 +297,20 @@ func createBlocksyncReactor(config *cfg.Config,
 		if config.BlockSync.ExitOnInvalidBlock {
 			bcReactor.(*blocksync.Reactor).SetExitOnInvalidBlock()
 		}
+		if config.P2P.TrustedPeerIDs != "" {
+			ids := strings.Split(config.P2P.TrustedPeerIDs, ",")
+			trustedPeerIDs := make([]p2p.ID, len(ids))
+			for i, id := range ids {
+				err := p2p.ValidateID(p2p.ID(id))
+				if err != nil {
+					return nil, fmt.Errorf("wrong ID #%d: %w", i, err)
+				}
+
+				trustedPeerIDs[i] = p2p.ID(id)
+			}
+
+			bcReactor.(*blocksync.Reactor).SetTrustedPeerIDs(trustedPeerIDs)
+		}
 	case "v1", "v2":
 		return nil, fmt.Errorf("block sync version %s has been deprecated. Please use v0", config.BlockSync.Version)
 	default:

--- a/p2p/netaddress.go
+++ b/p2p/netaddress.go
@@ -418,3 +418,8 @@ func validateID(id ID) error {
 	}
 	return nil
 }
+
+// ValidateID validates an ID.
+func ValidateID(id ID) error {
+	return validateID(id)
+}

--- a/state/mocks/block_store.go
+++ b/state/mocks/block_store.go
@@ -412,6 +412,24 @@ func (_m *BlockStore) SaveInvalidBlock(reason string, height int64) {
 	_m.Called(reason, height)
 }
 
+// SaveSeenCommit provides a mock function with given fields: height, seenCommit
+func (_m *BlockStore) SaveSeenCommit(height int64, seenCommit *types.Commit) error {
+	ret := _m.Called(height, seenCommit)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SaveSeenCommit")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(int64, *types.Commit) error); ok {
+		r0 = rf(height, seenCommit)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Size provides a mock function with no fields
 func (_m *BlockStore) Size() int64 {
 	ret := _m.Called()

--- a/state/services.go
+++ b/state/services.go
@@ -29,6 +29,7 @@ type BlockStore interface {
 	SaveBlock(block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit)
 	SaveBlockWithExtendedCommit(block *types.Block, blockParts *types.PartSet, seenCommit *types.ExtendedCommit)
 	SaveInvalidBlock(reason string, height int64)
+	SaveSeenCommit(height int64, seenCommit *types.Commit) error
 
 	PruneBlocks(height int64, state State) (uint64, int64, error)
 

--- a/types/block.go
+++ b/types/block.go
@@ -48,6 +48,9 @@ type Block struct {
 	Data         `json:"data"`
 	Evidence     EvidenceData `json:"evidence"`
 	LastCommit   *Commit      `json:"last_commit"`
+
+	// Trusted is true if the block is provided by a trusted peer
+	Trusted bool
 }
 
 // ValidateBasic performs basic validation that doesn't involve state data.


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

non-validator node will keep using block sync mode for better sync speed.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a mechanism to specify trusted peer IDs for enhanced peer-to-peer networking.
  - Added functionality to identify and mark blocks from trusted peers, improving block processing logic.
  - Enhanced configuration options with a new field for trusted peer IDs in the P2P settings.
  - Added methods to check validator status based on node state.
  - New functionality for saving seen commits associated with specific block heights.

- **Bug Fixes**
  - Improved error handling for invalid trusted peer IDs during configuration setup.

- **Documentation**
  - Updated configuration templates to include the new trusted peer IDs option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->