### PR TITLE
panic when validator failed to sign a vote

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2484,7 +2484,7 @@ func (cs *State) signAddVote(
 	vote, err := cs.signVote(msgType, hash, header, block)
 	if err != nil {
 		cs.Logger.Error("failed signing vote", "height", cs.Height, "round", cs.Round, "vote", vote, "err", err)
-		return
+		panic(err)
 	}
 	hasExt := len(vote.ExtensionSignature) > 0
 	extEnabled := cs.state.ConsensusParams.ABCI.VoteExtensionsEnabled(vote.Height)


### PR DESCRIPTION
If a validator fails to sign a vote, it waits for other votes until 2/3 consensus is reached. However, since we only have one validator, a failure results in an indefinite waiting state. To trigger a new signing request, we need to force a panic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated error handling in the vote signing process so that critical errors now trigger an immediate halt. This adjustment helps ensure that issues are promptly surfaced during operations, promoting quicker attention and resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->