### PR TITLE
fix: prevent block generation from queued tx in the mempool

### DIFF
--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -442,15 +442,25 @@ func (mem *CListMempool) resCbFirstTime(
 				tx:        tx,
 			}
 			memTx.addSender(txInfo.SenderID)
-			mem.addTx(memTx)
-			mem.logger.Debug(
-				"added good transaction",
-				"tx", types.Tx(tx).Hash(),
-				"res", r,
-				"height", mem.height.Load(),
-				"total", mem.Size(),
-			)
-			mem.notifyTxsAvailable()
+
+			// if the tx is valid and non-txqueue codespace, then add it to the mempool and notify listeners
+			if r.CheckTx.Codespace != "txqueue" {
+				mem.addTx(memTx)
+				mem.logger.Debug(
+					"added good transaction",
+					"tx", types.Tx(tx).Hash(),
+					"res", r,
+					"height", mem.height.Load(),
+					"total", mem.Size(),
+				)
+				mem.notifyTxsAvailable()
+			} else {
+				mem.logger.Debug(
+					"added txqueue transaction",
+					"tx", types.Tx(tx).Hash(),
+					"res", r,
+				)
+			}
 		} else {
 			// ignore bad transaction
 			mem.logger.Debug(


### PR DESCRIPTION
## Summary

We’ve introduced a new component called txqueue in MiniEVM, which enables us to manage queued transactions within the CometBFT mempool. This enhancement ensures that transactions can persist in the mempool, even when they are not in sequence.

However, if there are unordered transactions in the mempool and the sender fails to submit properly sequenced ones, the mempool may continuously emit misleading "transactions available" notifications, despite no valid transactions being ready for execution.

To address this issue, we will not add queued txs into comet mempool. but it should work properly in all case because we are checking previous block's num txs at consensus [here](https://github.com/initia-labs/cometbft/blob/edfb178d9ce85dd41dc2694d1fa631ae2af23579/consensus/state.go#L1137-L1141).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Transactions with a "txqueue" codespace are now excluded from being added to the mempool, while still being acknowledged in logs. Other valid transactions continue to be added as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->