### PR TITLE
Revert "fix: prevent block generation from queued tx in the mempool"

### DIFF
--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -442,25 +442,15 @@ func (mem *CListMempool) resCbFirstTime(
 				tx:        tx,
 			}
 			memTx.addSender(txInfo.SenderID)
-
-			// if the tx is valid and non-txqueue codespace, then add it to the mempool and notify listeners
-			if r.CheckTx.Codespace != "txqueue" {
-				mem.addTx(memTx)
-				mem.logger.Debug(
-					"added good transaction",
-					"tx", types.Tx(tx).Hash(),
-					"res", r,
-					"height", mem.height.Load(),
-					"total", mem.Size(),
-				)
-				mem.notifyTxsAvailable()
-			} else {
-				mem.logger.Debug(
-					"added txqueue transaction",
-					"tx", types.Tx(tx).Hash(),
-					"res", r,
-				)
-			}
+			mem.addTx(memTx)
+			mem.logger.Debug(
+				"added good transaction",
+				"tx", types.Tx(tx).Hash(),
+				"res", r,
+				"height", mem.height.Load(),
+				"total", mem.Size(),
+			)
+			mem.notifyTxsAvailable()
 		} else {
 			// ignore bad transaction
 			mem.logger.Debug(


### PR DESCRIPTION
Reverts initia-labs/cometbft#23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved transaction handling by ensuring all valid transactions are added to the mempool and trigger notifications, regardless of their codespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->