### PR TITLE
fix: do not trigger tx available notification, if there is no valid tx in the mempool

### DIFF
--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -674,7 +674,7 @@ func (mem *CListMempool) recheckTxs() {
 
 		// check if the tx is too old to be in the mempool
 		if mempoolTx := e.Value.(*mempoolTx); height > mempoolTx.height+MaxQueuedTxRetainHeight {
-			mem.logger.Debug("tx is removed from the mempool with timeout", "height", height, "max-height", mempoolTx.height+MaxQueuedTxRetainHeight)
+			mem.logger.Debug("tx is removed from the mempool with timeout", "tx", mempoolTx.tx.Hash(), "height", height, "max-height", mempoolTx.height+MaxQueuedTxRetainHeight)
 			if err := mem.RemoveTxByKey(mempoolTx.tx.Key()); err != nil {
 				mem.logger.Debug("Transaction could not be removed from mempool", "err", err)
 			}

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -493,11 +493,6 @@ func (mem *CListMempool) resCbRecheck(tx types.Tx, res *abci.ResponseCheckTx) {
 		postCheckErr = mem.postCheck(tx, res)
 	}
 
-	// if the tx is valid and non-txqueue codespace, and we haven't seen a valid recheck tx yet, set the flag
-	if res.Code == abci.CodeTypeOK && res.Codespace != "txqueue" && !mem.hasValidRecheckTxs.Load() {
-		mem.hasValidRecheckTxs.Store(true)
-	}
-
 	if (res.Code != abci.CodeTypeOK) || postCheckErr != nil {
 		// Tx became invalidated due to newly committed block.
 		mem.logger.Debug("tx is no longer valid", "tx", tx.Hash(), "res", res, "postCheckErr", postCheckErr)
@@ -508,6 +503,9 @@ func (mem *CListMempool) resCbRecheck(tx types.Tx, res *abci.ResponseCheckTx) {
 			mem.cache.Remove(tx)
 			mem.metrics.EvictedTxs.Add(1)
 		}
+	} else if res.Code == abci.CodeTypeOK && res.Codespace != "txqueue" && !mem.hasValidRecheckTxs.Load() {
+		// if the tx is valid and non-txqueue codespace, and we haven't seen a valid recheck tx yet, set the flag
+		mem.hasValidRecheckTxs.Store(true)
 	}
 }
 
@@ -652,6 +650,10 @@ func (mem *CListMempool) Update(
 	return nil
 }
 
+// MaxQueuedTxRetainHeight is the maximum height that a transaction can be queued for rechecking.
+// This is to prevent the mempool from holding onto transactions that are too old to be rechecked.
+const MaxQueuedTxRetainHeight = 100
+
 // recheckTxs sends all transactions in the mempool to the app for re-validation. When the function
 // returns, all recheck responses from the app have been processed.
 func (mem *CListMempool) recheckTxs() {
@@ -665,8 +667,18 @@ func (mem *CListMempool) recheckTxs() {
 
 	// NOTE: globalCb may be called concurrently, but CheckTx cannot be executed concurrently
 	// because this function has the lock (via Update and Lock).
+	height := mem.height.Load()
 	for e := mem.txs.Front(); e != nil; e = e.Next() {
-		tx := e.Value.(*mempoolTx).tx
+		mempoolTx := e.Value.(*mempoolTx)
+		if mempoolTx.Height()+MaxQueuedTxRetainHeight > height {
+			mem.logger.Debug("tx is too old to be rechecked", "tx", mempoolTx.tx.Hash(), "height", mempoolTx.Height(), "max-height", height+MaxQueuedTxRetainHeight)
+			if err := mem.RemoveTxByKey(mempoolTx.tx.Key()); err != nil {
+				mem.logger.Debug("Transaction could not be removed from mempool", "err", err)
+			}
+			continue
+		}
+
+		tx := mempoolTx.tx
 		mem.recheck.numPendingTxs.Add(1)
 
 		// Send a CheckTx request to the app. If we're using a sync client, the resCbRecheck

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -454,7 +454,9 @@ func (mem *CListMempool) resCbFirstTime(
 				"height", mem.height.Load(),
 				"total", mem.Size(),
 			)
-			mem.notifyTxsAvailable()
+			if r.CheckTx.Codespace != "txqueue" {
+				mem.notifyTxsAvailable()
+			}
 		} else {
 			// ignore bad transaction
 			mem.logger.Debug(
@@ -669,16 +671,22 @@ func (mem *CListMempool) recheckTxs() {
 	// because this function has the lock (via Update and Lock).
 	height := mem.height.Load()
 	for e := mem.txs.Front(); e != nil; e = e.Next() {
-		mempoolTx := e.Value.(*mempoolTx)
-		if mempoolTx.Height()+MaxQueuedTxRetainHeight > height {
-			mem.logger.Debug("tx is too old to be rechecked", "tx", mempoolTx.tx.Hash(), "height", mempoolTx.Height(), "max-height", height+MaxQueuedTxRetainHeight)
+
+		// check if the tx is too old to be in the mempool
+		if mempoolTx := e.Value.(*mempoolTx); height < mempoolTx.height+MaxQueuedTxRetainHeight {
+			mem.logger.Debug("tx is removed from mempool with timeout", "height", mempoolTx.height, "max-height", height+MaxQueuedTxRetainHeight)
 			if err := mem.RemoveTxByKey(mempoolTx.tx.Key()); err != nil {
 				mem.logger.Debug("Transaction could not be removed from mempool", "err", err)
 			}
+			if !mem.config.KeepInvalidTxsInCache {
+				mem.cache.Remove(mempoolTx.tx)
+				mem.metrics.EvictedTxs.Add(1)
+			}
+
 			continue
 		}
 
-		tx := mempoolTx.tx
+		tx := e.Value.(*mempoolTx).tx
 		mem.recheck.numPendingTxs.Add(1)
 
 		// Send a CheckTx request to the app. If we're using a sync client, the resCbRecheck

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -673,7 +673,7 @@ func (mem *CListMempool) recheckTxs() {
 	for e := mem.txs.Front(); e != nil; e = e.Next() {
 
 		// check if the tx is too old to be in the mempool
-		if mempoolTx := e.Value.(*mempoolTx); height < mempoolTx.height+MaxQueuedTxRetainHeight {
+		if mempoolTx := e.Value.(*mempoolTx); height > mempoolTx.height+MaxQueuedTxRetainHeight {
 			mem.logger.Debug("tx is removed from mempool with timeout", "height", mempoolTx.height, "max-height", height+MaxQueuedTxRetainHeight)
 			if err := mem.RemoveTxByKey(mempoolTx.tx.Key()); err != nil {
 				mem.logger.Debug("Transaction could not be removed from mempool", "err", err)

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -674,7 +674,7 @@ func (mem *CListMempool) recheckTxs() {
 
 		// check if the tx is too old to be in the mempool
 		if mempoolTx := e.Value.(*mempoolTx); height > mempoolTx.height+MaxQueuedTxRetainHeight {
-			mem.logger.Debug("tx is removed from mempool with timeout", "height", mempoolTx.height, "max-height", height+MaxQueuedTxRetainHeight)
+			mem.logger.Debug("tx is removed from the mempool with timeout", "height", mempoolTx.height, "max-height", height+MaxQueuedTxRetainHeight)
 			if err := mem.RemoveTxByKey(mempoolTx.tx.Key()); err != nil {
 				mem.logger.Debug("Transaction could not be removed from mempool", "err", err)
 			}

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -505,7 +505,7 @@ func (mem *CListMempool) resCbRecheck(tx types.Tx, res *abci.ResponseCheckTx) {
 			mem.cache.Remove(tx)
 			mem.metrics.EvictedTxs.Add(1)
 		}
-	} else if res.Code == abci.CodeTypeOK && res.Codespace != "txqueue" && !mem.hasValidRecheckTxs.Load() {
+	} else if res.Codespace != "txqueue" && !mem.hasValidRecheckTxs.Load() {
 		// if the tx is valid and non-txqueue codespace, and we haven't seen a valid recheck tx yet, set the flag
 		mem.hasValidRecheckTxs.Store(true)
 	}

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -55,6 +55,10 @@ type CListMempool struct {
 
 	logger  log.Logger
 	metrics *Metrics
+
+	// hasValidRecheckTxs indicates whether any transaction has been successfully rechecked
+	// with a non-txqueue codespace response, meaning it's ready for inclusion in a block
+	hasValidRecheckTxs atomic.Bool
 }
 
 var _ Mempool = &CListMempool{}
@@ -489,6 +493,11 @@ func (mem *CListMempool) resCbRecheck(tx types.Tx, res *abci.ResponseCheckTx) {
 		postCheckErr = mem.postCheck(tx, res)
 	}
 
+	// if the tx is valid and non-txqueue codespace, and we haven't seen a valid recheck tx yet, set the flag
+	if res.Code == abci.CodeTypeOK && res.Codespace != "txqueue" && !mem.hasValidRecheckTxs.Load() {
+		mem.hasValidRecheckTxs.Store(true)
+	}
+
 	if (res.Code != abci.CodeTypeOK) || postCheckErr != nil {
 		// Tx became invalidated due to newly committed block.
 		mem.logger.Debug("tx is no longer valid", "tx", tx.Hash(), "res", res, "postCheckErr", postCheckErr)
@@ -591,6 +600,7 @@ func (mem *CListMempool) Update(
 	// Set height
 	mem.height.Store(height)
 	mem.notifiedTxsAvailable.Store(false)
+	mem.hasValidRecheckTxs.Store(false)
 
 	if preCheck != nil {
 		mem.preCheck = preCheck
@@ -630,8 +640,8 @@ func (mem *CListMempool) Update(
 		mem.recheckTxs()
 	}
 
-	// Notify if there are still txs left in the mempool.
-	if mem.Size() > 0 {
+	// Notify if there are still valid txs left in the mempool.
+	if mem.Size() > 0 && mem.hasValidRecheckTxs.Load() {
 		mem.notifyTxsAvailable()
 	}
 

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -674,7 +674,7 @@ func (mem *CListMempool) recheckTxs() {
 
 		// check if the tx is too old to be in the mempool
 		if mempoolTx := e.Value.(*mempoolTx); height > mempoolTx.height+MaxQueuedTxRetainHeight {
-			mem.logger.Debug("tx is removed from the mempool with timeout", "height", mempoolTx.height, "max-height", height+MaxQueuedTxRetainHeight)
+			mem.logger.Debug("tx is removed from the mempool with timeout", "height", height, "max-height", mempoolTx.height+MaxQueuedTxRetainHeight)
 			if err := mem.RemoveTxByKey(mempoolTx.tx.Key()); err != nil {
 				mem.logger.Debug("Transaction could not be removed from mempool", "err", err)
 			}


### PR DESCRIPTION
## Summary 

We’ve introduced a new component called txqueue in MiniEVM, which enables us to manage queued transactions within the CometBFT mempool. This enhancement ensures that transactions can persist in the mempool, even when they are not in sequence.

However, if there are unordered transactions in the mempool and the sender fails to submit properly sequenced ones, the mempool may continuously emit misleading "transactions available" notifications, despite no valid transactions being ready for execution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction notification logic to ensure notifications are only sent when valid transactions are available after rechecking. This enhances accuracy and reliability for users monitoring transaction availability.
  - Removed stale transactions from the mempool after a defined retention period, preventing outdated transactions from affecting performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->