### PR TITLE
keep PeerStatsRoutine running even consensus state stop

### DIFF
--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -1042,8 +1042,6 @@ func (conR *Reactor) peerStatsRoutine() {
 					conR.Switch.MarkPeerAsGood(peer)
 				}
 			}
-		case <-conR.conS.Quit():
-			return
 
 		case <-conR.Quit():
 			return


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the shutdown process for the peer statistics routine, which now only responds to the reactor's own quit signal. This may affect when the routine stops running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->