### PR TITLE
fix: block search v2 access during migration

### DIFF
--- a/rpc/core/blocks.go
+++ b/rpc/core/blocks.go
@@ -296,6 +296,15 @@ func (env *Environment) blockSearchV2(
 	pagePtr, perPagePtr *int,
 	orderBy string,
 ) (*ctypes.ResultBlockSearch, error) {
+	// during migration, we return an error to indicate the service is temporarily unavailable
+	if env.BlockIndexerV2.IsMigrating() {
+		migrationHeight, err := env.BlockIndexerV2.MigrationHeight()
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("BlockSearchV2 is not ready yet, migration height: %d", migrationHeight)
+	}
+
 	// skip if block indexing is disabled
 	if _, ok := env.BlockIndexerV2.(*blockidxv2null.BlockerIndexer); ok {
 		return nil, errors.New("block indexing is disabled")

--- a/rpc/core/tx.go
+++ b/rpc/core/tx.go
@@ -170,6 +170,15 @@ func (env *Environment) txSearchV2(
 	pagePtr, perPagePtr *int,
 	orderBy string,
 ) (*ctypes.ResultTxSearch, error) {
+	// during migration, we return an error to indicate the service is temporarily unavailable
+	if env.TxIndexerV2.IsMigrating() {
+		migrationHeight, err := env.TxIndexerV2.MigrationHeight()
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("TxSearchV2 is not ready yet, migration height: %d", migrationHeight)
+	}
+
 	// if index is disabled, return error
 	if _, ok := env.TxIndexerV2.(*null.TxIndexV2); ok {
 		return nil, errors.New("transaction indexing is disabled")


### PR DESCRIPTION
Prevent returning incorrect information during migration