### PR TITLE
increase timeout & move CommitRound = -1 to reset

### DIFF
--- a/blocksync/pool.go
+++ b/blocksync/pool.go
@@ -55,7 +55,7 @@ const (
 	minBlocksForSingleRequest = 50
 )
 
-var peerTimeout = 60 * time.Second // not const so we can override with tests
+var peerTimeout = 90 * time.Second // not const so we can override with tests
 
 /*
 	Peers self report their heights when we join the block pool.

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -153,7 +153,7 @@ func (conR *Reactor) SwitchToConsensus(state sm.State, skipWAL bool) {
 	err := conR.conS.Start()
 	if err != nil {
 		panic(fmt.Sprintf(`Failed to start consensus state: %v
-
+ 
 conS:
 %+v
 
@@ -162,6 +162,7 @@ conR:
 	}
 }
 
+// switchToBlockSync switches to block sync mode
 func (conR *Reactor) switchToBlockSync() error {
 	if conR.blockSyncReactor == nil {
 		return fmt.Errorf("block sync reactor is not set")
@@ -169,19 +170,17 @@ func (conR *Reactor) switchToBlockSync() error {
 
 	conR.Logger.Info("switchToBlockSync")
 
+	// stop state and wait for it to stop
+	// reset state for later use
 	err := conR.conS.Stop()
 	if err != nil {
 		return err
 	}
-
 	conR.conS.Wait()
-
 	err = conR.conS.Reset()
 	if err != nil {
 		return err
 	}
-	// reset commit round to -1 to ignore current consensus state
-	conR.conS.CommitRound = -1
 
 	conR.mtx.Lock()
 	conR.waitSync = true

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -464,6 +464,9 @@ func (cs *State) OnReset() error {
 	cs.wal = nilWAL{}
 	cs.done = make(chan struct{})
 
+	// reset commit round to -1 to ignore current consensus state
+	cs.CommitRound = -1
+
 	return nil
 }
 


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of consensus state resets by explicitly resetting the commit round, ensuring accurate state after a reset.
  - Increased peer timeout duration from 60 seconds to 90 seconds, which may help with network stability.

- **Documentation**
  - Added clarifying comments to consensus state transitions for better understanding of internal processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->