### PR TITLE
fix(blocksync): prevent mislabeling second peer as slow when syncing latest blocks

### DIFF
--- a/blocksync/pool.go
+++ b/blocksync/pool.go
@@ -361,9 +361,7 @@ func (pool *BlockPool) AddBlock(peerID p2p.ID, block *types.Block, extCommit *ty
 			pool.sendError(err, peerID)
 			return err
 		}
-	}
-
-	if !requester.setBlock(block, extCommit, peerID) {
+	} else if !requester.setBlock(block, extCommit, peerID) {
 		err := fmt.Errorf("requested block #%d from %v, not %s", block.Height, requester.requestedFrom(), peerID)
 		pool.sendError(err, peerID)
 		return err

--- a/blocksync/pool.go
+++ b/blocksync/pool.go
@@ -361,8 +361,6 @@ func (pool *BlockPool) AddBlock(peerID p2p.ID, block *types.Block, extCommit *ty
 			pool.sendError(err, peerID)
 			return err
 		}
-
-		return fmt.Errorf("got an already committed block #%d (possibly from the slow peer %s)", block.Height, peerID)
 	}
 
 	if !requester.setBlock(block, extCommit, peerID) {

--- a/blocksync/pool.go
+++ b/blocksync/pool.go
@@ -361,18 +361,19 @@ func (pool *BlockPool) AddBlock(peerID p2p.ID, block *types.Block, extCommit *ty
 			pool.sendError(err, peerID)
 			return err
 		}
-	} else if !requester.setBlock(block, extCommit, peerID) {
-		err := fmt.Errorf("requested block #%d from %v, not %s", block.Height, requester.requestedFrom(), peerID)
-		pool.sendError(err, peerID)
-		return err
+	} else {
+		if !requester.setBlock(block, extCommit, peerID) {
+			err := fmt.Errorf("requested block #%d from %v, not %s", block.Height, requester.requestedFrom(), peerID)
+			pool.sendError(err, peerID)
+			return err
+		}
+		atomic.AddInt32(&pool.numPending, -1)
 	}
 
-	atomic.AddInt32(&pool.numPending, -1)
 	peer := pool.peers[peerID]
 	if peer != nil {
 		peer.decrPending(blockSize)
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
## Description

We’ve added a new feature that allows a block to be applied immediately—without waiting for the next block—if it is received from a trusted peer. However, this change may cause issues with minRecvRate in the current CometBFT structure. Specifically, CometBFT may incorrectly flag a peer as slow if the block has already been applied. With our modification, this behavior becomes common and expected in normal environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of already committed blocks by ignoring duplicate block submissions instead of returning an error. This prevents unnecessary errors when receiving blocks that have already been processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->