### PR TITLE
fix: enforce to remove block when # of rollback height > 1

### DIFF
--- a/state/rollback.go
+++ b/state/rollback.go
@@ -146,6 +146,8 @@ func RollbackTo(bs BlockStore, ss Store, rollbackHeight int64, removeBlock bool)
 	// rollback 1 block
 	if invalidState.LastBlockHeight == rollbackHeight+1 {
 		return Rollback(bs, ss, removeBlock)
+	} else {
+		removeBlock = true
 	}
 
 	// state store height is equal to blockstore height. We're good to proceed with rolling back state


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rollback handling to ensure blocks are correctly removed when rolling back more than one block.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->