### PR TITLE
fix: limit txsPerPage to 100 and ignore same block when receiving block from batch

### DIFF
--- a/rollupsync/block.go
+++ b/rollupsync/block.go
@@ -21,7 +21,7 @@ LOOP:
 			if blockInfo.Block != nil {
 				block := blockInfo.Block
 
-				if block.Height <= rs.state.LastBlockHeight {
+				if block.Height < rs.state.LastBlockHeight {
 					if block.Height == 1 {
 						rs.logger.Info("ignore genesis block")
 						continue

--- a/rollupsync/block.go
+++ b/rollupsync/block.go
@@ -29,7 +29,7 @@ LOOP:
 
 					// end rollup syncer
 					return fmt.Errorf("need to rollback to height %d", block.Height-1)
-				} else if rs.state.LastBlockHeight+1 < block.Height {
+				} else if rs.state.LastBlockHeight+1 < block.Height || rs.state.LastBlockHeight == block.Height {
 					// rs.logger.Info("block height mismatch", "expected", rs.state.LastBlockHeight+1, "got", block.Height)
 					// ignore invalid block
 					continue

--- a/rollupsync/provider/batch.go
+++ b/rollupsync/provider/batch.go
@@ -132,7 +132,7 @@ func (bp *BatchProvider) fetchBatch(ctx context.Context, batchCh chan<- rstypes.
 		return true, nil
 	}
 
-	txsPerPage := min(100, int(bp.cfg.TxsPerPage))
+	txsPerPage := min(maxTxsPerPage, int(bp.cfg.TxsPerPage))
 	queryStr := fmt.Sprintf("tx.height >= %d AND tx.height < %d AND %s", height, nextHeight, rstypes.QueryEventTypeWithSubmitterFromChainType(bp.chainType, bp.submitter))
 	res, err := bp.client.TxSearch(ctx, queryStr, false, &page, &txsPerPage, "asc")
 	if err != nil {

--- a/rollupsync/provider/batch.go
+++ b/rollupsync/provider/batch.go
@@ -132,7 +132,7 @@ func (bp *BatchProvider) fetchBatch(ctx context.Context, batchCh chan<- rstypes.
 		return true, nil
 	}
 
-	txsPerPage := int(bp.cfg.TxsPerPage)
+	txsPerPage := min(100, int(bp.cfg.TxsPerPage))
 	queryStr := fmt.Sprintf("tx.height >= %d AND tx.height < %d AND %s", height, nextHeight, rstypes.QueryEventTypeWithSubmitterFromChainType(bp.chainType, bp.submitter))
 	res, err := bp.client.TxSearch(ctx, queryStr, false, &page, &txsPerPage, "asc")
 	if err != nil {

--- a/rollupsync/provider/utils.go
+++ b/rollupsync/provider/utils.go
@@ -15,6 +15,8 @@ import (
 	"github.com/celestiaorg/go-square/v2/tx"
 )
 
+const maxTxsPerPage = 100
+
 // newRpcClient sets up a new RPC client
 func newRpcClient(server string) (*rpchttp.HTTP, error) {
 	if !strings.Contains(server, "://") {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Tightened block height check to avoid unnecessary rollbacks for equal-height blocks, improving sync stability.
  - Capped transactions per page during batch fetching to a safe maximum, reducing oversized requests and improving fetch reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->