### PR TITLE
fix: prevent dos by checking duplication

### DIFF
--- a/sequencing/types/bucket.go
+++ b/sequencing/types/bucket.go
@@ -115,10 +115,16 @@ func (b *P2PBucket[T]) Add(id p2p.ID, height int64, value T) {
 		queue = nil
 	}
 
-	entry := bucketEntry[T]{height: height, value: value}
+	// Reject duplicates for a given peer/height combination to avoid
+	// unbounded memory usage from repeated proposals.
 	idx := sort.Search(len(queue), func(i int) bool {
-		return entry.height < queue[i].height
+		return queue[i].height >= height
 	})
+	if idx < len(queue) && queue[idx].height == height {
+		return
+	}
+
+	entry := bucketEntry[T]{height: height, value: value}
 	frontChanged := idx == 0
 	if idx == len(queue) {
 		queue = append(queue, entry)

--- a/sequencing/types/bucket_test.go
+++ b/sequencing/types/bucket_test.go
@@ -146,3 +146,26 @@ func TestBlockBucketHasHeightAndRemove(t *testing.T) {
 		t.Fatalf("removal of unknown height should fail")
 	}
 }
+
+func TestBlockBucketDeduplicatesPerPeerHeight(t *testing.T) {
+	bucket := NewP2PBucket[*ProposedBlock]()
+
+	block := &ProposedBlock{}
+	bucket.Add(p2p.ID("peer1"), 10, block)
+	bucket.Add(p2p.ID("peer1"), 10, &ProposedBlock{}) // duplicate height from same peer
+
+	if bucket.Len() != 1 {
+		t.Fatalf("expected duplicates to be dropped, length is %d", bucket.Len())
+	}
+	if bucket.PeerLen(p2p.ID("peer1")) != 1 {
+		t.Fatalf("expected peer queue length 1, got %d", bucket.PeerLen(p2p.ID("peer1")))
+	}
+
+	id, height, value, ok := bucket.PopLowest()
+	if !ok || id != p2p.ID("peer1") || height != 10 || value != block {
+		t.Fatalf("unexpected pop result: ok=%t id=%s height=%d value=%v", ok, id, height, value)
+	}
+	if !bucket.IsEmpty() {
+		t.Fatalf("bucket should be empty after popping the single entry")
+	}
+}


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Prevents duplicate block proposals from the same peer at identical heights, filtering duplicates before insertion to maintain data integrity.

## Tests
* Added test coverage validating the duplicate prevention logic for peer-height combinations to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->