### PR TITLE
fix: create_empty_blocks_interval config check

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1034,7 +1034,7 @@ func (cfg *SequencingConfig) ValidateBasic() error {
 	if !cfg.CreateEmptyBlocks && cfg.CreateEmptyBlocksInterval <= 0 {
 		return errors.New("create_empty_blocks_interval must be greater than 0")
 	}
-	if cfg.CreateEmptyBlocksInterval < cfg.BlockInterval {
+	if !cfg.CreateEmptyBlocks && cfg.CreateEmptyBlocksInterval < cfg.BlockInterval {
 		return errors.New("create_empty_blocks_interval must be greater than block_interval")
 	}
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -1034,6 +1034,9 @@ func (cfg *SequencingConfig) ValidateBasic() error {
 	if !cfg.CreateEmptyBlocks && cfg.CreateEmptyBlocksInterval <= 0 {
 		return errors.New("create_empty_blocks_interval must be greater than 0")
 	}
+	if cfg.CreateEmptyBlocksInterval < cfg.BlockInterval {
+		return errors.New("create_empty_blocks_interval must be greater than block_interval")
+	}
 	return nil
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened configuration validation: when empty-block creation is disabled, the configured interval for creating empty blocks must be at least as long as the block interval, preventing inconsistent interval settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->