### PR TITLE
feat: stop sequencing engine when we detect app upgrade

### DIFF
--- a/sequencing/engine/handlers.go
+++ b/sequencing/engine/handlers.go
@@ -16,7 +16,7 @@ import (
 	cmttime "github.com/cometbft/cometbft/types/time"
 )
 
-var upgradeNeededRegexp = regexp.MustCompile(`.*UPGRADE .* NEEDED.*`)
+var upgradeNeededRegexp = regexp.MustCompile(`UPGRADE .* NEEDED`)
 
 // applyProposedBlock applies a proposed block message from a peer.
 func (e *Engine) applyProposedBlock(pb *types.ProposedBlock) (badPeer, applied, upgrade bool) {

--- a/sequencing/engine/handlers.go
+++ b/sequencing/engine/handlers.go
@@ -16,7 +16,7 @@ import (
 	cmttime "github.com/cometbft/cometbft/types/time"
 )
 
-var upgradeNeededRegexp = regexp.MustCompile(`UPGRADE .* NEEDED`)
+var upgradeNeededRegex = regexp.MustCompile(`UPGRADE .* NEEDED`)
 
 // applyProposedBlock applies a proposed block message from a peer.
 func (e *Engine) applyProposedBlock(pb *types.ProposedBlock) (badPeer, applied, upgrade bool) {
@@ -57,9 +57,9 @@ func (e *Engine) applyProposedBlock(pb *types.ProposedBlock) (badPeer, applied, 
 	state, err = e.blockExec.ApplyVerifiedBlock(state, blockID, pb.Block)
 	if err != nil {
 		// when an upgrade is needed, we do not panic, just log and stop the engine
-		if upgradeNeededRegexp.MatchString(err.Error()) {
+		if upgradeNeededRegex.MatchString(err.Error()) {
 			e.logger.Error("node upgrade required", "height", pb.Block.Height, "err", err)
-			e.Stop()
+			_ = e.Stop()
 			return false, false, true
 		}
 

--- a/sequencing/engine/handlers.go
+++ b/sequencing/engine/handlers.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -15,10 +16,12 @@ import (
 	cmttime "github.com/cometbft/cometbft/types/time"
 )
 
+var upgradeNeededRegexp = regexp.MustCompile(`.*UPGRADE .* NEEDED.*`)
+
 // applyProposedBlock applies a proposed block message from a peer.
-func (e *Engine) applyProposedBlock(pb *types.ProposedBlock) (badPeer bool, applied bool) {
+func (e *Engine) applyProposedBlock(pb *types.ProposedBlock) (badPeer, applied, upgrade bool) {
 	if pb == nil || pb.Block == nil || pb.Commit == nil {
-		return false, false
+		return false, false, false
 	}
 
 	e.stateMu.Lock()
@@ -26,7 +29,7 @@ func (e *Engine) applyProposedBlock(pb *types.ProposedBlock) (badPeer bool, appl
 	e.stateMu.Unlock()
 
 	if pb.Block.Height <= state.LastBlockHeight {
-		return false, false
+		return false, false, false
 	}
 
 	// validate the block
@@ -34,14 +37,14 @@ func (e *Engine) applyProposedBlock(pb *types.ProposedBlock) (badPeer bool, appl
 	if err != nil {
 		e.logger.Error("failed to make block parts", "height", pb.Block.Height, "err", err)
 
-		return true, false
+		return true, false, false
 	}
 
 	blockID := cmttypes.BlockID{Hash: pb.Block.Hash(), PartSetHeader: blockParts.Header()}
 	if err := state.Validators.VerifySequencerCommit(state.ChainID, blockID, pb.Block.Height, pb.Commit.ToCommit()); err != nil {
 		e.logger.Error("failed to validate commit", "height", pb.Block.Height, "err", err)
 
-		return true, false
+		return true, false, false
 	}
 	if err := e.blockExec.ValidateBlock(state, pb.Block); err != nil {
 		panic(fmt.Sprintf("CONSENSUS FAILURE!!! Proposed block failed validation: block (%d:%X): %v", pb.Block.Height, pb.Block.Hash(), err))
@@ -53,6 +56,13 @@ func (e *Engine) applyProposedBlock(pb *types.ProposedBlock) (badPeer bool, appl
 	// apply the block
 	state, err = e.blockExec.ApplyVerifiedBlock(state, blockID, pb.Block)
 	if err != nil {
+		// when an upgrade is needed, we do not panic, just log and stop the engine
+		if upgradeNeededRegexp.MatchString(err.Error()) {
+			e.logger.Info("node upgrade required", "height", pb.Block.Height, "err", err)
+			e.Stop()
+			return false, false, true
+		}
+
 		panic(fmt.Sprintf("Failed to process committed block (%d:%X): %v", pb.Block.Height, pb.Block.Hash(), err))
 	}
 
@@ -71,7 +81,7 @@ func (e *Engine) applyProposedBlock(pb *types.ProposedBlock) (badPeer bool, appl
 	// signal the block has been applied
 	e.signalBlockApplied()
 
-	return false, true
+	return false, true, false
 }
 
 // applyAttestorCommit applies an attestor commit message from a peer.

--- a/sequencing/engine/handlers.go
+++ b/sequencing/engine/handlers.go
@@ -58,7 +58,7 @@ func (e *Engine) applyProposedBlock(pb *types.ProposedBlock) (badPeer, applied, 
 	if err != nil {
 		// when an upgrade is needed, we do not panic, just log and stop the engine
 		if upgradeNeededRegexp.MatchString(err.Error()) {
-			e.logger.Info("node upgrade required", "height", pb.Block.Height, "err", err)
+			e.logger.Error("node upgrade required", "height", pb.Block.Height, "err", err)
 			e.Stop()
 			return false, false, true
 		}

--- a/sequencing/engine/processors.go
+++ b/sequencing/engine/processors.go
@@ -13,10 +13,17 @@ const (
 
 func (e *Engine) blockProcessor() {
 	ticker := time.NewTicker(syncInterval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
 			for {
+				select {
+				case <-e.stopCh:
+					return
+				default:
+				}
+
 				e.stateMu.Lock()
 				stateHeight := e.state.LastBlockHeight
 				e.stateMu.Unlock()
@@ -55,7 +62,9 @@ func (e *Engine) blockProcessor() {
 				// try to register event bus after we receive block
 				e.tryRegisterEventBus()
 
-				if badPeer, applied := e.applyProposedBlock(proposedBlock); badPeer {
+				if badPeer, applied, upgrade := e.applyProposedBlock(proposedBlock); upgrade {
+					return
+				} else if badPeer {
 					e.flagBadPeer(pid, "sent invalid proposed block")
 				} else if applied {
 					e.logger.Info("applied proposed block", "peer", pid, "height", height)
@@ -73,7 +82,6 @@ func (e *Engine) blockProcessor() {
 			}
 
 		case <-e.stopCh:
-			ticker.Stop()
 			return
 		}
 	}
@@ -81,10 +89,17 @@ func (e *Engine) blockProcessor() {
 
 func (e *Engine) attesterCommitProcessor() {
 	ticker := time.NewTicker(syncInterval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
 			for {
+				select {
+				case <-e.stopCh:
+					return
+				default:
+				}
+
 				id, height, attestorCommit, ok := e.commitBucket.PopLowest()
 				if !ok {
 					break
@@ -111,7 +126,6 @@ func (e *Engine) attesterCommitProcessor() {
 			}
 
 		case <-e.stopCh:
-			ticker.Stop()
 			return
 		}
 	}
@@ -119,12 +133,12 @@ func (e *Engine) attesterCommitProcessor() {
 
 func (e *Engine) statusProcessor() {
 	ticker := time.NewTicker(statusInterval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
 			e.broadcastStatus()
 		case <-e.stopCh:
-			ticker.Stop()
 			return
 		}
 	}
@@ -132,6 +146,7 @@ func (e *Engine) statusProcessor() {
 
 func (e *Engine) proposerProcessor() {
 	ticker := time.NewTicker(proposeInterval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
@@ -141,7 +156,6 @@ func (e *Engine) proposerProcessor() {
 		case <-e.reactor.TxsAvailable():
 			e.proposeBlock()
 		case <-e.stopCh:
-			ticker.Stop()
 			return
 		}
 	}
@@ -149,6 +163,7 @@ func (e *Engine) proposerProcessor() {
 
 func (e *Engine) attestorProcessor() {
 	ticker := time.NewTicker(attestInterval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
@@ -156,7 +171,6 @@ func (e *Engine) attestorProcessor() {
 		case <-e.appliedCh:
 			e.attestBlock()
 		case <-e.stopCh:
-			ticker.Stop()
 			return
 		}
 	}
@@ -177,6 +191,7 @@ func (e *Engine) conflictingVoteProcessor() {
 
 func (e *Engine) badPeerCleanup() {
 	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
@@ -189,7 +204,6 @@ func (e *Engine) badPeerCleanup() {
 				return true
 			})
 		case <-e.stopCh:
-			ticker.Stop()
 			return
 		}
 	}

--- a/sequencing/engine/proposer_test.go
+++ b/sequencing/engine/proposer_test.go
@@ -213,9 +213,10 @@ func produceAndApplyBlock(t *testing.T, eng *Engine) *seqtypes.ProposedBlock {
 	require.True(t, ok)
 	require.Equal(t, proposed.Block.Height, height)
 
-	bad, applied := eng.applyProposedBlock(proposed)
+	bad, applied, upgrade := eng.applyProposedBlock(proposed)
 	require.False(t, bad)
 	require.True(t, applied)
+	require.False(t, upgrade)
 
 	require.NoError(t, eng.blockStore.SaveSeenCommit(height, proposed.Commit.ToCommit()))
 


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detects upgrade-required conditions and gracefully stops the engine instead of crashing.
  * Prevents error paths from causing unexpected behavior during block application.

* **Improvements**
  * Processors now respond faster to shutdown/stop signals and exit promptly.
  * Ensures periodic timers are always stopped for more reliable resource cleanup.

* **Tests**
  * Updated tests to handle the new upgrade signal from block application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->