### PR TITLE
feat: use real time as block time

### DIFF
--- a/node/node_test.go
+++ b/node/node_test.go
@@ -473,7 +473,7 @@ func state(nVals int, height int64) (sm.State, dbm.DB, []types.PrivValidator) {
 		vals[i] = types.GenesisValidator{
 			Address: privVal.PrivKey.PubKey().Address(),
 			PubKey:  privVal.PrivKey.PubKey(),
-			Power:   1000,
+			Power:   1,
 			Name:    fmt.Sprintf("test%d", i),
 		}
 	}

--- a/sequencing/engine/handlers.go
+++ b/sequencing/engine/handlers.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cometbft/cometbft/p2p"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	"github.com/cometbft/cometbft/sequencing/types"
-	cmtstate "github.com/cometbft/cometbft/state"
 	cmttypes "github.com/cometbft/cometbft/types"
 	cmttime "github.com/cometbft/cometbft/types/time"
 )
@@ -69,7 +68,7 @@ func (e *Engine) applyProposedBlock(pb *types.ProposedBlock) (badPeer, applied, 
 	e.stateMu.Lock()
 	*e.state = state
 	e.lastProposedBlockHeight = pb.Block.Height
-	e.lastProposedBlockTime = cmtstate.MedianTime(pb.Commit.ToCommit(), state.LastValidators)
+	e.lastProposedBlockTime = pb.Block.Time
 	e.lastProposedBlockNumTxs = len(pb.Block.Data.Txs)
 
 	// try to update our role in case validator set changed

--- a/sequencing/engine/handlers.go
+++ b/sequencing/engine/handlers.go
@@ -17,10 +17,6 @@ import (
 
 var upgradeNeededRegex = regexp.MustCompile(`UPGRADE .* NEEDED`)
 
-const (
-	allowedFutureBlockTime = 15 * time.Second // Max seconds from current time allowed for blocks, before they're considered future blocks
-)
-
 // applyProposedBlock applies a proposed block message from a peer.
 func (e *Engine) applyProposedBlock(pb *types.ProposedBlock) (badPeer, applied, upgrade bool) {
 	if pb == nil || pb.Block == nil || pb.Commit == nil {
@@ -189,12 +185,6 @@ func (e *Engine) attestBlock() {
 	height := e.blockStore.Height()
 	block := e.blockStore.LoadBlock(height)
 	if block == nil {
-		return
-	}
-
-	// refuse to sign if block time is in the future
-	if block.Time.After(cmttime.Now().Add(allowedFutureBlockTime)) {
-		e.logger.Info("refusing to attest block with future timestamp", "height", height, "block_time", block.Time)
 		return
 	}
 

--- a/sequencing/engine/handlers.go
+++ b/sequencing/engine/handlers.go
@@ -17,6 +17,10 @@ import (
 
 var upgradeNeededRegex = regexp.MustCompile(`UPGRADE .* NEEDED`)
 
+const (
+	allowedFutureBlockTime = 15 * time.Second // Max seconds from current time allowed for blocks, before they're considered future blocks
+)
+
 // applyProposedBlock applies a proposed block message from a peer.
 func (e *Engine) applyProposedBlock(pb *types.ProposedBlock) (badPeer, applied, upgrade bool) {
 	if pb == nil || pb.Block == nil || pb.Commit == nil {
@@ -185,6 +189,12 @@ func (e *Engine) attestBlock() {
 	height := e.blockStore.Height()
 	block := e.blockStore.LoadBlock(height)
 	if block == nil {
+		return
+	}
+
+	// refuse to sign if block time is in the future
+	if block.Time.After(cmttime.Now().Add(allowedFutureBlockTime)) {
+		e.logger.Info("refusing to attest block with future timestamp", "height", height, "block_time", block.Time)
 		return
 	}
 

--- a/state/state.go
+++ b/state/state.go
@@ -247,7 +247,7 @@ func (state State) MakeBlock(
 	if height == state.InitialHeight {
 		timestamp = state.LastBlockTime // genesis time
 	} else {
-		// in sequencing reactor, we set block time to now or last block time + 1ms, whichever is later
+		// SEQUENCING: use local time instead of MedianTime(lastCommit)
 		timestamp = LocalTime(state.LastBlockTime)
 	}
 

--- a/state/state.go
+++ b/state/state.go
@@ -247,7 +247,12 @@ func (state State) MakeBlock(
 	if height == state.InitialHeight {
 		timestamp = state.LastBlockTime // genesis time
 	} else {
-		timestamp = MedianTime(lastCommit, state.LastValidators)
+		// in sequencing reactor, we set block time to now or last block time + 1ms, whichever is later
+		timestamp = cmttime.Now().UTC()
+		minBlockTime := state.LastBlockTime.Add(time.Millisecond)
+		if timestamp.Before(minBlockTime) {
+			timestamp = minBlockTime
+		}
 	}
 
 	// Fill rest of header with state data.
@@ -260,29 +265,6 @@ func (state State) MakeBlock(
 	)
 
 	return block
-}
-
-// MedianTime computes a median time for a given Commit (based on Timestamp field of votes messages) and the
-// corresponding validator set. The computed time is always between timestamps of
-// the votes sent by honest processes, i.e., a faulty processes can not arbitrarily increase or decrease the
-// computed value.
-func MedianTime(commit *types.Commit, validators *types.ValidatorSet) time.Time {
-	weightedTimes := make([]*cmttime.WeightedTime, len(commit.Signatures))
-	totalVotingPower := int64(0)
-
-	for i, commitSig := range commit.Signatures {
-		if commitSig.BlockIDFlag == types.BlockIDFlagAbsent {
-			continue
-		}
-		_, validator := validators.GetByAddress(commitSig.ValidatorAddress)
-		// If there's no condition, TestValidateBlockCommit panics; not needed normally.
-		if validator != nil {
-			totalVotingPower += validator.VotingPower
-			weightedTimes[i] = cmttime.NewWeightedTime(commitSig.Timestamp, validator.VotingPower)
-		}
-	}
-
-	return cmttime.WeightedMedian(weightedTimes, totalVotingPower)
 }
 
 //------------------------------------------------------------------------

--- a/state/state.go
+++ b/state/state.go
@@ -248,11 +248,7 @@ func (state State) MakeBlock(
 		timestamp = state.LastBlockTime // genesis time
 	} else {
 		// in sequencing reactor, we set block time to now or last block time + 1ms, whichever is later
-		timestamp = cmttime.Now().UTC()
-		minBlockTime := state.LastBlockTime.Add(time.Millisecond)
-		if timestamp.Before(minBlockTime) {
-			timestamp = minBlockTime
-		}
+		timestamp = LocalTime(state.LastBlockTime)
 	}
 
 	// Fill rest of header with state data.
@@ -265,6 +261,16 @@ func (state State) MakeBlock(
 	)
 
 	return block
+}
+
+// LocalTime returns the local time for a new block based on the last block time.
+func LocalTime(lastBlockTime time.Time) time.Time {
+	timestamp := cmttime.Now().UTC()
+	minBlockTime := lastBlockTime.Add(time.Millisecond)
+	if timestamp.Before(minBlockTime) {
+		timestamp = minBlockTime
+	}
+	return timestamp
 }
 
 //------------------------------------------------------------------------

--- a/state/validation.go
+++ b/state/validation.go
@@ -119,13 +119,6 @@ func validateBlock(state State, block *types.Block) error {
 				state.LastBlockTime,
 			)
 		}
-		medianTime := MedianTime(block.LastCommit, state.LastValidators)
-		if !block.Time.Equal(medianTime) {
-			return fmt.Errorf("invalid block time. Expected %v, got %v",
-				medianTime,
-				block.Time,
-			)
-		}
 
 	case block.Height == state.InitialHeight:
 		genesisTime := state.LastBlockTime

--- a/state/validation.go
+++ b/state/validation.go
@@ -4,9 +4,15 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/types"
+	cmttime "github.com/cometbft/cometbft/types/time"
+)
+
+const (
+	allowedFutureBlockTime = 15 * time.Second // Max seconds from current time allowed for blocks, before they're considered future blocks
 )
 
 //-----------------------------------------------------
@@ -117,6 +123,14 @@ func validateBlock(state State, block *types.Block) error {
 			return fmt.Errorf("block time %v not greater than last block time %v",
 				block.Time,
 				state.LastBlockTime,
+			)
+		}
+
+		// SEQUENCING: verify block time is not too far in the future
+		if block.Time.After(cmttime.Now().Add(allowedFutureBlockTime)) {
+			return fmt.Errorf("block time %v is too far in the future (max %v)",
+				block.Time,
+				cmttime.Now().Add(allowedFutureBlockTime),
 			)
 		}
 

--- a/state/validation.go
+++ b/state/validation.go
@@ -127,10 +127,10 @@ func validateBlock(state State, block *types.Block) error {
 		}
 
 		// SEQUENCING: verify block time is not too far in the future
-		if block.Time.After(cmttime.Now().Add(allowedFutureBlockTime)) {
+		if maxAllowedTime := block.Time.After(cmttime.Now().Add(allowedFutureBlockTime)); maxAllowedTime {
 			return fmt.Errorf("block time %v is too far in the future (max %v)",
 				block.Time,
-				cmttime.Now().Add(allowedFutureBlockTime),
+				maxAllowedTime,
 			)
 		}
 

--- a/state/validation.go
+++ b/state/validation.go
@@ -4,9 +4,15 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/types"
+	cmttime "github.com/cometbft/cometbft/types/time"
+)
+
+const (
+	allowedFutureBlockTime = 15 * time.Second // Max seconds from current time allowed for blocks, before they're considered future blocks
 )
 
 //-----------------------------------------------------
@@ -117,6 +123,14 @@ func validateBlock(state State, block *types.Block) error {
 			return fmt.Errorf("block time %v not greater than last block time %v",
 				block.Time,
 				state.LastBlockTime,
+			)
+		}
+
+		if timestamp := cmttime.Now().UTC(); block.Time.After(timestamp.Add(allowedFutureBlockTime)) {
+			return fmt.Errorf("block time %v is too far in the future (more than %s ahead of local time %v)",
+				block.Time,
+				allowedFutureBlockTime.String(),
+				timestamp,
 			)
 		}
 

--- a/state/validation.go
+++ b/state/validation.go
@@ -4,15 +4,9 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/types"
-	cmttime "github.com/cometbft/cometbft/types/time"
-)
-
-const (
-	allowedFutureBlockTime = 15 * time.Second // Max seconds from current time allowed for blocks, before they're considered future blocks
 )
 
 //-----------------------------------------------------
@@ -123,14 +117,6 @@ func validateBlock(state State, block *types.Block) error {
 			return fmt.Errorf("block time %v not greater than last block time %v",
 				block.Time,
 				state.LastBlockTime,
-			)
-		}
-
-		if timestamp := cmttime.Now().UTC(); block.Time.After(timestamp.Add(allowedFutureBlockTime)) {
-			return fmt.Errorf("block time %v is too far in the future (more than %s ahead of local time %v)",
-				block.Time,
-				allowedFutureBlockTime.String(),
-				timestamp,
 			)
 		}
 

--- a/state/validation.go
+++ b/state/validation.go
@@ -127,7 +127,7 @@ func validateBlock(state State, block *types.Block) error {
 		}
 
 		// SEQUENCING: verify block time is not too far in the future
-		if maxAllowedTime := block.Time.After(cmttime.Now().Add(allowedFutureBlockTime)); maxAllowedTime {
+		if maxAllowedTime := cmttime.Now().Add(allowedFutureBlockTime); block.Time.After(maxAllowedTime) {
 			return fmt.Errorf("block time %v is too far in the future (max %v)",
 				block.Time,
 				maxAllowedTime,


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

## Changes

In Sequencing reactor, we don't need to use median(previous block commits) as block time, but we can directly use sequencer's local time as block time.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Block timestamps now use local current UTC time with guaranteed forward progression; median-based timestamp computation removed.

* **Validation**
  * Block time validation simplified: blocks must be after the previous block, and nodes reject blocks that are slightly too far in the future (small allowance).

* **Tests**
  * Genesis test setup adjusted: initial validator powers reduced, lowering default test voting power.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->