### PR TITLE
fix: enhance graceful shutdown

### DIFF
--- a/sequencing/engine/handlers.go
+++ b/sequencing/engine/handlers.go
@@ -67,9 +67,11 @@ func (e *Engine) applyProposedBlock(pb *types.ProposedBlock) (badPeer, applied, 
 
 	e.stateMu.Lock()
 	*e.state = state
-	e.lastProposedBlockHeight = pb.Block.Height
-	e.lastProposedBlockTime = pb.Block.Time
-	e.lastProposedBlockNumTxs = len(pb.Block.Data.Txs)
+	if e.lastProposedBlockHeight < pb.Block.Height {
+		e.lastProposedBlockHeight = pb.Block.Height
+		e.lastProposedBlockTime = pb.Block.Time
+		e.lastProposedBlockNumTxs = len(pb.Block.Data.Txs)
+	}
 
 	// try to update our role in case validator set changed
 	e.switchRoleLocked()
@@ -395,6 +397,8 @@ func (e *Engine) proposeBlock() {
 	// keep track of last proposed height to prevent entering this function too often
 	e.stateMu.Lock()
 	e.lastProposedBlockHeight = height
+	e.lastProposedBlockTime = proposedBlock.Time
+	e.lastProposedBlockNumTxs = len(proposedBlock.Data.Txs)
 	e.stateMu.Unlock()
 }
 

--- a/sequencing/engine/processors.go
+++ b/sequencing/engine/processors.go
@@ -89,7 +89,7 @@ func (e *Engine) blockProcessor() {
 
 			// ensure blocks up to last proposed block height are processed
 			// to do not lose our own proposals
-			if stateHeight >= lastProposedBlockHeight {
+			if lastProposedBlockHeight == 0 || stateHeight >= lastProposedBlockHeight {
 				return
 			}
 		}

--- a/sequencing/engine/processors.go
+++ b/sequencing/engine/processors.go
@@ -82,7 +82,15 @@ func (e *Engine) blockProcessor() {
 			}
 
 		case <-e.stopCh:
-			return
+			e.stateMu.Lock()
+			stateHeight := e.state.LastBlockHeight
+			e.stateMu.Unlock()
+
+			// ensure blocks up to last proposed block height are processed
+			// to do not lose our own proposals
+			if stateHeight >= e.lastProposedBlockHeight {
+				return
+			}
 		}
 	}
 }

--- a/sequencing/engine/processors.go
+++ b/sequencing/engine/processors.go
@@ -84,11 +84,12 @@ func (e *Engine) blockProcessor() {
 		case <-e.stopCh:
 			e.stateMu.Lock()
 			stateHeight := e.state.LastBlockHeight
+			lastProposedBlockHeight := e.lastProposedBlockHeight
 			e.stateMu.Unlock()
 
 			// ensure blocks up to last proposed block height are processed
 			// to do not lose our own proposals
-			if stateHeight >= e.lastProposedBlockHeight {
+			if stateHeight >= lastProposedBlockHeight {
 				return
 			}
 		}


### PR DESCRIPTION
## Changes

If a node was shutdown without applying the proposed block, then we will lose the signed block and keep refuse to sign it.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented loss of proposed blocks during shutdown by ensuring block processing continues until all pending proposals are handled.
  * Improved proposal tracking so proposal height, time, and transaction counts are recorded only when a newer proposal arrives, avoiding overwrites with equal or older proposals.
  * Ensured shutdown logic compares persisted block progress with pending proposals to avoid premature halting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->