### PR TITLE
fix: rollupsync to skip blocks if the synced block is lower than synced height

### DIFF
--- a/rollupsync/block.go
+++ b/rollupsync/block.go
@@ -2,7 +2,6 @@ package rollupsync
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cometbft/cometbft/types"
 )
@@ -27,8 +26,10 @@ LOOP:
 						continue
 					}
 
-					// end rollup syncer
-					return fmt.Errorf("need to rollback to height %d", block.Height-1)
+					rs.logger.Info("ignore block lower than last synced height",
+						"height", block.Height,
+						"last_synced_height", rs.state.LastBlockHeight)
+					continue
 				} else if rs.state.LastBlockHeight+1 < block.Height || rs.state.LastBlockHeight == block.Height {
 					rs.logger.Error("block height mismatch", "expected", rs.state.LastBlockHeight+1, "got", block.Height)
 					// ignore invalid block
@@ -50,13 +51,17 @@ LOOP:
 				blockPartSetHeader := blockParts.Header()
 				blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: blockPartSetHeader}
 
-				rs.state, err = rs.blockExec.ApplyBlock(rs.state, blockID, block)
+				state, err := rs.blockExec.ApplyBlock(rs.state, blockID, block)
 				if err != nil {
 					rs.logger.Error("failed to apply block",
 						"height", block.Height,
 						"err", err.Error())
 					continue
 				}
+
+				// update state
+				rs.state = state
+
 				// we don't need to save seen commit here, seen commit is used only in consensus.
 				rs.blockStore.SaveBlock(block, blockParts, nil)
 			} else if blockInfo.Commit != nil {


### PR DESCRIPTION
## Descriptions

To handle upgrade case, we need to just skip the installed block if the block height is lower than synced one.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block synchronization resilience: blocks lower than the last synced height now log an informational message and continue processing instead of triggering a rollback error, reducing synchronization interruptions and enhancing system stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->