### PR TITLE
feat: re-gossip mempool txs to peers if recheck is successful

### DIFF
--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -59,6 +59,10 @@ type CListMempool struct {
 	// hasValidTxs indicates whether any transaction has been successfully checked
 	// with a non-txqueue codespace response, meaning it's ready for inclusion in a block
 	hasValidTxs atomic.Bool
+
+	// gossipTxs keeps track of txs that need to be gossiped to peers
+	gossipTxs []*mempoolTx
+	gossipMut sync.Mutex
 }
 
 var _ Mempool = &CListMempool{}
@@ -510,21 +514,16 @@ func (mem *CListMempool) resCbRecheck(tx types.Tx, res *abci.ResponseCheckTx) {
 			mem.cache.Remove(tx)
 			mem.metrics.EvictedTxs.Add(1)
 		}
-	} else if res.Codespace != "txqueue" && !mem.hasValidTxs.Load() {
+	} else if res.Codespace != "txqueue" {
 		// if the tx is valid and non-txqueue codespace, and we haven't seen a valid recheck tx yet, set the flag
-		mem.hasValidTxs.Store(true)
+		if !mem.hasValidTxs.Load() {
+			mem.hasValidTxs.Store(true)
+		}
 
-		// move tx back to the end of the list to re-notify availability to peers
-		if elem, ok := mem.getCElement(tx.Key()); ok {
-			mempoolTx := mem.txs.Remove(elem)
-
-			elem.DetachPrev()
-			elem.DetachNext()
-
-			if mempoolTx != nil {
-				mem.txs.PushBack(mempoolTx)
-			}
-
+		if memTx := mem.getMemTx(tx.Key()); memTx != nil {
+			mem.gossipMut.Lock()
+			mem.gossipTxs = append(mem.gossipTxs, memTx)
+			mem.gossipMut.Unlock()
 		}
 	}
 }
@@ -619,6 +618,11 @@ func (mem *CListMempool) Update(
 	mem.height.Store(height)
 	mem.notifiedTxsAvailable.Store(false)
 	mem.hasValidTxs.Store(false)
+
+	// Clear gossipTxs map
+	mem.gossipMut.Lock()
+	mem.gossipTxs = mem.gossipTxs[:0]
+	mem.gossipMut.Unlock()
 
 	if preCheck != nil {
 		mem.preCheck = preCheck

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -513,6 +513,19 @@ func (mem *CListMempool) resCbRecheck(tx types.Tx, res *abci.ResponseCheckTx) {
 	} else if res.Codespace != "txqueue" && !mem.hasValidTxs.Load() {
 		// if the tx is valid and non-txqueue codespace, and we haven't seen a valid recheck tx yet, set the flag
 		mem.hasValidTxs.Store(true)
+
+		// move tx back to the end of the list to re-notify availability to peers
+		if elem, ok := mem.getCElement(tx.Key()); ok {
+			mempoolTx := mem.txs.Remove(elem)
+
+			elem.DetachPrev()
+			elem.DetachNext()
+
+			if mempoolTx != nil {
+				mem.txs.PushBack(mempoolTx)
+			}
+
+		}
 	}
 }
 

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -61,7 +61,7 @@ type CListMempool struct {
 	hasValidTxs atomic.Bool
 
 	// gossipTxs keeps track of txs that need to be gossiped to peers
-	gossipTxs []*mempoolTx
+	gossipTxs []types.TxKey
 	gossipMut sync.Mutex
 }
 
@@ -520,11 +520,9 @@ func (mem *CListMempool) resCbRecheck(tx types.Tx, res *abci.ResponseCheckTx) {
 			mem.hasValidTxs.Store(true)
 		}
 
-		if memTx := mem.getMemTx(tx.Key()); memTx != nil {
-			mem.gossipMut.Lock()
-			mem.gossipTxs = append(mem.gossipTxs, memTx)
-			mem.gossipMut.Unlock()
-		}
+		mem.gossipMut.Lock()
+		mem.gossipTxs = append(mem.gossipTxs, tx.Key())
+		mem.gossipMut.Unlock()
 	}
 }
 

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -124,6 +124,7 @@ func (memR *Reactor) AddPeer(peer p2p.Peer) {
 
 			memR.mempool.metrics.ActiveOutboundConnections.Add(1)
 			defer memR.mempool.metrics.ActiveOutboundConnections.Add(-1)
+			go memR.gossipTxRoutine(peer)
 			memR.broadcastTxRoutine(peer)
 		}()
 	}
@@ -170,6 +171,55 @@ func (memR *Reactor) Receive(e p2p.Envelope) {
 // PeerState describes the state of a peer.
 type PeerState interface {
 	GetHeight() int64
+}
+
+func (memR *Reactor) gossipTxRoutine(peer p2p.Peer) {
+	var lastGossipHeight int64 = -1
+
+	for {
+		// In case of both next.NextWaitChan() and peer.Quit() are variable at the same time
+		if !memR.IsRunning() || !peer.IsRunning() {
+			return
+		}
+
+		// Make sure the peer is up to date.
+		peerState, ok := peer.Get(types.PeerStateKey).(PeerState)
+		if !ok {
+			time.Sleep(PeerCatchupSleepIntervalMS * time.Millisecond)
+			continue
+		}
+
+		mempoolHeight := memR.mempool.height.Load()
+		if lastGossipHeight >= mempoolHeight {
+			time.Sleep(PeerCatchupSleepIntervalMS * time.Millisecond)
+			continue
+		}
+
+		lastGossipHeight = mempoolHeight
+		peerHeight := peerState.GetHeight()
+
+		memR.mempool.gossipMut.Lock()
+		gossipTxs := []*mempoolTx{}
+		copy(gossipTxs, memR.mempool.gossipTxs)
+		memR.mempool.gossipMut.Unlock()
+
+		for _, memTx := range gossipTxs {
+			if !memR.IsRunning() || !peer.IsRunning() {
+				return
+			}
+			// allow for a lag of 1 block
+			if peerHeight < memTx.Height()-1 {
+				continue
+			}
+			if success := peer.Send(p2p.Envelope{
+				ChannelID: MempoolChannel,
+				Message:   &protomem.Txs{Txs: [][]byte{memTx.tx}},
+			}); !success {
+				time.Sleep(PeerCatchupSleepIntervalMS * time.Millisecond)
+				continue
+			}
+		}
+	}
 }
 
 // Send new mempool txs to peer.

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -199,15 +199,19 @@ func (memR *Reactor) gossipTxRoutine(peer p2p.Peer) {
 		peerHeight := peerState.GetHeight()
 
 		memR.mempool.gossipMut.Lock()
-		gossipTxs := []*mempoolTx{}
+		gossipTxs := []types.TxKey{}
 		copy(gossipTxs, memR.mempool.gossipTxs)
 		memR.mempool.gossipMut.Unlock()
 
-		for _, memTx := range gossipTxs {
+		for _, txKey := range gossipTxs {
 			if !memR.IsRunning() || !peer.IsRunning() {
 				return
 			}
 			// allow for a lag of 1 block
+			memTx := memR.mempool.getMemTx(txKey)
+			if memTx == nil {
+				continue
+			}
 			if peerHeight < memTx.Height()-1 {
 				continue
 			}

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -199,7 +199,7 @@ func (memR *Reactor) gossipTxRoutine(peer p2p.Peer) {
 		peerHeight := peerState.GetHeight()
 
 		memR.mempool.gossipMut.Lock()
-		gossipTxs := []types.TxKey{}
+		gossipTxs := make([]types.TxKey, len(memR.mempool.gossipTxs))
 		copy(gossipTxs, memR.mempool.gossipTxs)
 		memR.mempool.gossipMut.Unlock()
 


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Peers now receive mempool transactions via an additional continuous gossip path, improving timely propagation.
  * Rechecked-valid transactions are queued for gossiping and will be sent to peers when appropriate; gossip state is cleared on mempool updates.

* **Bug Fixes**
  * Improved mempool transaction ordering by reordering valid transactions to the end of the queue during recheck validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->