### PR TITLE
feat(rpc): expose CometBFT mempool for in-process access

### DIFF
--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cometbft/cometbft/libs/log"
 	cmtpubsub "github.com/cometbft/cometbft/libs/pubsub"
 	cmtquery "github.com/cometbft/cometbft/libs/pubsub/query"
+	mempl "github.com/cometbft/cometbft/mempool"
 	nm "github.com/cometbft/cometbft/node"
 	rpcclient "github.com/cometbft/cometbft/rpc/client"
 	"github.com/cometbft/cometbft/rpc/core"
@@ -59,6 +60,16 @@ func New(node *nm.Node) *Local {
 }
 
 var _ rpcclient.Client = (*Local)(nil)
+
+// Mempool returns the CometBFT mempool from the local node's RPC environment.
+// This allows in-process callers (e.g. the app's PostSetup hook) to access
+// the mempool for event channel wiring without going through the server layer.
+func (c *Local) Mempool() mempl.Mempool {
+	if c.env != nil {
+		return c.env.Mempool
+	}
+	return nil
+}
 
 // SetLogger allows to set a logger on the client.
 func (c *Local) SetLogger(l log.Logger) {


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Local RPC clients can now access mempool information to view pending transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->