### PR TITLE
feat(mempool): in-flight guard for CheckTx

### DIFF
--- a/mempool/proxy_mempool.go
+++ b/mempool/proxy_mempool.go
@@ -32,6 +32,9 @@ type ProxyMempool struct {
 	knownTxCount atomic.Int64
 	knownTxBytes atomic.Int64
 
+	// in-flight CheckTx guard: txKey -> struct{} while the abci call is pending
+	inCheckTxs sync.Map
+
 	txsAvailable         chan struct{}
 	notifiedTxsAvailable atomic.Bool
 	hasValidTxs          atomic.Bool
@@ -119,12 +122,20 @@ func (mp *ProxyMempool) CheckTx(
 		return ErrTxInCache
 	}
 
+	// prevent duplicate in-flight CheckTx calls for the same tx
+	if _, loaded := mp.inCheckTxs.LoadOrStore(txKey, struct{}{}); loaded {
+		return ErrTxInCache
+	}
+
 	reqRes, err := mp.proxyAppConn.CheckTxAsync(context.TODO(), &abci.RequestCheckTx{Tx: tx})
 	if err != nil {
+		mp.inCheckTxs.Delete(txKey)
 		return ErrAppConnMempool{Err: err}
 	}
 
 	reqRes.SetCallback(func(res *abci.Response) {
+		mp.inCheckTxs.Delete(txKey)
+
 		checkTxRes := res.GetCheckTx()
 		if checkTxRes == nil {
 			return
@@ -225,7 +236,7 @@ func (mp *ProxyMempool) FlushAppConn() error {
 	return nil
 }
 
-// Flush clears the knownTxs cache.
+// Flush clears all mempool state.
 func (mp *ProxyMempool) Flush() {
 	mp.knownTxs.Range(func(key, _ interface{}) bool {
 		mp.knownTxs.Delete(key)
@@ -233,6 +244,8 @@ func (mp *ProxyMempool) Flush() {
 	})
 	mp.knownTxCount.Store(0)
 	mp.knownTxBytes.Store(0)
+	mp.includedTxCache.Reset()
+	mp.hasValidTxs.Store(false)
 }
 
 // TxsAvailable returns a channel that fires once per height when transactions are available in the mempool.

--- a/mempool/proxy_mempool.go
+++ b/mempool/proxy_mempool.go
@@ -246,6 +246,10 @@ func (mp *ProxyMempool) Flush() {
 	mp.knownTxBytes.Store(0)
 	mp.includedTxCache.Reset()
 	mp.hasValidTxs.Store(false)
+	mp.inCheckTxs.Range(func(key, _ interface{}) bool {
+		mp.inCheckTxs.Delete(key)
+		return true
+	})
 }
 
 // TxsAvailable returns a channel that fires once per height when transactions are available in the mempool.


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplicate concurrent transaction validation requests to reduce redundant work.
  * Ensures in-flight validation state is correctly cleared on both success and error to avoid stale locks.
  * Improves reset/flush behavior to fully clear validation caches and in-flight tracking for consistent state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->