### PR TITLE
fix(sequencing): crash-safe block proposal with persistent pending storage

### DIFF
--- a/sequencing/engine/engine.go
+++ b/sequencing/engine/engine.go
@@ -50,9 +50,6 @@ type Engine struct {
 	lastProposedBlockTime   time.Time
 	lastProposedBlockNumTxs int
 
-	// only used for graceful shutdown to apply last proposed block
-	lastProposedBlock *types.ProposedBlock
-
 	appliedCh          chan struct{}
 	receiveCh          chan p2pMsg
 	conflictingVotesCh chan conflictingCommit
@@ -222,17 +219,6 @@ func (e *Engine) Stop() error {
 
 func (e *Engine) Wait() {
 	<-e.done
-
-	// apply last proposed block if not applied yet
-	e.stateMu.Lock()
-	stateHeight := e.state.LastBlockHeight
-	lastProposedBlockHeight := e.lastProposedBlockHeight
-	lastProposedBlock := e.lastProposedBlock
-	e.stateMu.Unlock()
-
-	if lastProposedBlock != nil && lastProposedBlockHeight == stateHeight+1 {
-		_, _, _ = e.applyProposedBlock(lastProposedBlock)
-	}
 }
 
 // ResetState replaces the engine's working state and synchronizes related metadata.

--- a/sequencing/engine/handlers.go
+++ b/sequencing/engine/handlers.go
@@ -382,6 +382,7 @@ func (e *Engine) proposeBlock() {
 		// persist the block before signing so we can recover even if we crash mid-sign
 		if err := e.blockStore.SavePendingProposal(proposedBlock, nil); err != nil {
 			e.logger.Error("failed to save pending proposal (pre-sign)", "height", height, "err", err)
+			return
 		}
 	}
 

--- a/sequencing/engine/handlers.go
+++ b/sequencing/engine/handlers.go
@@ -60,6 +60,11 @@ func (e *Engine) applyProposedBlock(pb *types.ProposedBlock) (badPeer, applied, 
 	// store the block with the validator set
 	e.blockStore.SaveBlockWithValidatorSet(pb.Block, blockParts, pb.Commit.ToCommit(), state.Validators)
 
+	// block is now durably stored; clear the pending proposal if any
+	if err := e.blockStore.DeletePendingProposal(); err != nil {
+		e.logger.Error("failed to delete pending proposal", "height", pb.Block.Height, "err", err)
+	}
+
 	// apply the verified block
 	if e.applyVerifiedBlock(state, blockID, pb.Block) {
 		return false, false, true
@@ -350,78 +355,102 @@ func (e *Engine) proposeBlock() {
 		lastExtCommit = lastCommit.WrappedExtendedCommit()
 	}
 
-	e.logger.Info("proposing block", "height", height, "proposer", validator.Address)
-	e.execMu.Lock()
-	proposedBlock, err := e.blockExec.CreateProposalBlock(
-		context.Background(),
-		height,
-		state,
-		lastExtCommit,
-		proposerAddr,
-	)
-	e.execMu.Unlock()
-	if err != nil {
-		panic(fmt.Sprintf("Failed to create proposal block: height %d err %v", height, err))
+	// check for a persisted pending proposal from a previous run
+	var proposedBlock *cmttypes.Block
+	var extCommit *cmttypes.ExtendedCommit
+
+	pendingBlock, pendingCommit := e.blockStore.LoadPendingProposal()
+	if pendingBlock != nil && pendingBlock.Height == height {
+		e.logger.Info("recovering pending proposal", "height", height, "signed", pendingCommit != nil)
+		proposedBlock = pendingBlock
+		extCommit = pendingCommit // nil = pre-sign, non-nil = already signed
+	} else {
+		e.logger.Info("proposing block", "height", height, "proposer", validator.Address)
+		e.execMu.Lock()
+		var err error
+		proposedBlock, err = e.blockExec.CreateProposalBlock(
+			context.Background(),
+			height,
+			state,
+			lastExtCommit,
+			proposerAddr,
+		)
+		e.execMu.Unlock()
+		if err != nil {
+			panic(fmt.Sprintf("Failed to create proposal block: height %d err %v", height, err))
+		}
+		// persist the block before signing so we can recover even if we crash mid-sign
+		if err := e.blockStore.SavePendingProposal(proposedBlock, nil); err != nil {
+			e.logger.Error("failed to save pending proposal (pre-sign)", "height", height, "err", err)
+		}
 	}
+
 	proposedBlockID, err := blockID(proposedBlock)
 	if err != nil {
 		e.logger.Error("unable to compute block ID", "height", height, "err", err)
 		return
 	}
 
-	// create self vote
-	vote := &cmttypes.Vote{
-		ValidatorAddress: proposerAddr,
-		ValidatorIndex:   idx,
-		Height:           height,
-		Round:            0,
-		Timestamp:        voteTime(proposedBlock.Time),
-		Type:             cmtproto.PrecommitType,
-		BlockID:          proposedBlockID,
-	}
-
-	v := vote.ToProto()
-	if err = e.privValidator.SignVote(state.ChainID, v); err != nil {
-		if !ignoreSignErr(err) {
-			e.logger.Error("unable to sign proposal vote", "height", height, "err", err)
-		} else {
-			e.logger.Debug("ignoring error signing proposal vote", "height", height, "err", err)
+	if extCommit == nil {
+		// create self vote and sign
+		vote := &cmttypes.Vote{
+			ValidatorAddress: proposerAddr,
+			ValidatorIndex:   idx,
+			Height:           height,
+			Round:            0,
+			Timestamp:        voteTime(proposedBlock.Time),
+			Type:             cmtproto.PrecommitType,
+			BlockID:          proposedBlockID,
 		}
-		return
-	}
 
-	vote.Timestamp = v.Timestamp
-	vote.Signature = v.Signature
-	vote.ExtensionSignature = v.ExtensionSignature
-	signatures := make([]cmttypes.CommitSig, state.Validators.Size())
-	for i := range signatures {
-		signatures[i] = cmttypes.NewCommitSigAbsent()
+		v := vote.ToProto()
+		if err = e.privValidator.SignVote(state.ChainID, v); err != nil {
+			if !ignoreSignErr(err) {
+				e.logger.Error("unable to sign proposal vote", "height", height, "err", err)
+			} else {
+				e.logger.Debug("ignoring error signing proposal vote", "height", height, "err", err)
+			}
+			return
+		}
+
+		vote.Timestamp = v.Timestamp
+		vote.Signature = v.Signature
+		vote.ExtensionSignature = v.ExtensionSignature
+		signatures := make([]cmttypes.CommitSig, state.Validators.Size())
+		for i := range signatures {
+			signatures[i] = cmttypes.NewCommitSigAbsent()
+		}
+		commit := &cmttypes.Commit{
+			Height:     height,
+			BlockID:    proposedBlockID,
+			Signatures: signatures,
+		}
+		commit.Signatures[idx] = vote.CommitSig()
+		extCommit = commit.WrappedExtendedCommit()
+
+		// persist signed proposal so we can recover after signing but before apply
+		if err := e.blockStore.SavePendingProposal(proposedBlock, extCommit); err != nil {
+			e.logger.Error("failed to save pending proposal (post-sign)", "height", height, "err", err)
+		}
 	}
-	commit := &cmttypes.Commit{
-		Height:     height,
-		BlockID:    proposedBlockID,
-		Signatures: signatures,
-	}
-	commit.Signatures[idx] = vote.CommitSig()
 
 	proposed := &types.ProposedBlock{
 		Block:  proposedBlock,
-		Commit: commit.WrappedExtendedCommit(),
+		Commit: extCommit,
 	}
-
-	// add block to bucket as well
-	e.blockBucket.Add(types.SELF_PEER_ID, height, proposed)
-
-	// broadcast the proposed block
-	e.broadcastProposedBlock(proposed)
 
 	// keep track of last proposed height to prevent entering this function too often
 	e.stateMu.Lock()
 	e.lastProposedBlockHeight = height
 	e.lastProposedBlockTime = proposedBlock.Time
 	e.lastProposedBlockNumTxs = len(proposedBlock.Data.Txs)
-	e.lastProposedBlock = proposed // for graceful shutdown
 	e.stateMu.Unlock()
+
+	// add block to bucket as well
+	e.blockBucket.Add(types.SELF_PEER_ID, height, proposed)
+
+	// broadcast the proposed block
+	e.broadcastProposedBlock(proposed)
 }
 
 func voteTime(lastBlockTime time.Time) time.Time {

--- a/sequencing/engine/handlers.go
+++ b/sequencing/engine/handlers.go
@@ -380,10 +380,7 @@ func (e *Engine) proposeBlock() {
 			panic(fmt.Sprintf("Failed to create proposal block: height %d err %v", height, err))
 		}
 		// persist the block before signing so we can recover even if we crash mid-sign
-		if err := e.blockStore.SavePendingProposal(proposedBlock, nil); err != nil {
-			e.logger.Error("failed to save pending proposal (pre-sign)", "height", height, "err", err)
-			return
-		}
+		e.blockStore.SavePendingProposal(proposedBlock, nil)
 	}
 
 	proposedBlockID, err := blockID(proposedBlock)
@@ -430,9 +427,7 @@ func (e *Engine) proposeBlock() {
 		extCommit = commit.WrappedExtendedCommit()
 
 		// persist signed proposal so we can recover after signing but before apply
-		if err := e.blockStore.SavePendingProposal(proposedBlock, extCommit); err != nil {
-			e.logger.Error("failed to save pending proposal (post-sign)", "height", height, "err", err)
-		}
+		e.blockStore.SavePendingProposal(proposedBlock, extCommit)
 	}
 
 	proposed := &types.ProposedBlock{

--- a/sequencing/engine/proposer_test.go
+++ b/sequencing/engine/proposer_test.go
@@ -277,3 +277,101 @@ func TestProposerProcessorCreatesBlockOnTxsAvailable(t *testing.T) {
 		return eng.blockBucket.Len() > 0
 	}, 300*time.Millisecond, 20*time.Millisecond)
 }
+
+// resetForRestart mimics a fresh engine start: clears the tracking fields
+// that would be zero-valued on a real restart while keeping the block store.
+func resetForRestart(eng *Engine) {
+	eng.stateMu.Lock()
+	eng.lastProposedBlockHeight = 0
+	eng.lastProposedBlockTime = time.Time{}
+	eng.lastProposedBlockNumTxs = 0
+	eng.stateMu.Unlock()
+}
+
+// TestProposeBlockSavesPendingProposal verifies that proposeBlock persists
+// a signed pending proposal to the block store.
+func TestProposeBlockSavesPendingProposal(t *testing.T) {
+	eng, _, _ := newProposerTestEngine(t, 500*time.Millisecond)
+
+	b, c := eng.blockStore.LoadPendingProposal()
+	require.Nil(t, b)
+	require.Nil(t, c)
+
+	eng.proposeBlock()
+
+	b, c = eng.blockStore.LoadPendingProposal()
+	require.NotNil(t, b, "block should be persisted after proposeBlock")
+	require.NotNil(t, c, "signed commit should be persisted after proposeBlock")
+	require.Equal(t, int64(1), b.Height)
+}
+
+// TestProposeBlockDeletesPendingProposalOnApply verifies that
+// applyProposedBlock removes the pending proposal once the block is durable.
+func TestProposeBlockDeletesPendingProposalOnApply(t *testing.T) {
+	eng, _, _ := newProposerTestEngine(t, 500*time.Millisecond)
+
+	eng.proposeBlock()
+
+	b, _ := eng.blockStore.LoadPendingProposal()
+	require.NotNil(t, b, "pending proposal should exist before apply")
+
+	_, _, proposed, ok := eng.blockBucket.PopLowest()
+	require.True(t, ok)
+
+	bad, applied, _ := eng.applyProposedBlock(proposed)
+	require.False(t, bad)
+	require.True(t, applied)
+
+	b, _ = eng.blockStore.LoadPendingProposal()
+	require.Nil(t, b, "pending proposal should be deleted after apply")
+}
+
+// TestProposeBlockRecoversSigned verifies that when a signed pending proposal
+// exists for the current height on restart, proposeBlock reuses it without
+// re-creating or re-signing the block.
+func TestProposeBlockRecoversSigned(t *testing.T) {
+	eng, _, _ := newProposerTestEngine(t, 500*time.Millisecond)
+
+	eng.proposeBlock()
+
+	_, _, firstProposed, ok := eng.blockBucket.PopLowest()
+	require.True(t, ok)
+	originalHash := firstProposed.Block.Hash()
+
+	// Simulate restart: pending proposal is still in the block store,
+	// but the in-memory tracking fields are reset to zero values.
+	resetForRestart(eng)
+
+	eng.proposeBlock()
+
+	_, _, recovered, ok := eng.blockBucket.PopLowest()
+	require.True(t, ok, "block should be produced via recovery")
+	require.Equal(t, originalHash, recovered.Block.Hash(), "recovered block must have the same content")
+	require.Equal(t, firstProposed.Commit.Height, recovered.Commit.Height)
+}
+
+// TestProposeBlockRecoversUnsigned verifies that when only an unsigned
+// (pre-sign) pending proposal exists, proposeBlock reuses the block and
+// signs it again rather than creating a new block.
+func TestProposeBlockRecoversUnsigned(t *testing.T) {
+	eng, _, _ := newProposerTestEngine(t, 500*time.Millisecond)
+
+	eng.proposeBlock()
+
+	_, _, firstProposed, ok := eng.blockBucket.PopLowest()
+	require.True(t, ok)
+	originalHash := firstProposed.Block.Hash()
+
+	// Overwrite with the unsigned (pre-sign) state to simulate a crash
+	// that occurred after block creation but before signing.
+	require.NoError(t, eng.blockStore.SavePendingProposal(firstProposed.Block, nil))
+
+	resetForRestart(eng)
+
+	eng.proposeBlock()
+
+	_, _, recovered, ok := eng.blockBucket.PopLowest()
+	require.True(t, ok, "block should be produced via recovery")
+	require.Equal(t, originalHash, recovered.Block.Hash(), "recovered block must have the same content")
+	require.NotNil(t, recovered.Commit, "recovered block must be signed")
+}

--- a/sequencing/engine/proposer_test.go
+++ b/sequencing/engine/proposer_test.go
@@ -364,7 +364,7 @@ func TestProposeBlockRecoversUnsigned(t *testing.T) {
 
 	// Overwrite with the unsigned (pre-sign) state to simulate a crash
 	// that occurred after block creation but before signing.
-	require.NoError(t, eng.blockStore.SavePendingProposal(firstProposed.Block, nil))
+	eng.blockStore.SavePendingProposal(firstProposed.Block, nil)
 
 	resetForRestart(eng)
 

--- a/store/store.go
+++ b/store/store.go
@@ -773,10 +773,10 @@ var pendingProposalKey = []byte("PP")
 // SavePendingProposal persists a pending sequencer proposal.
 // Pass a nil commit to record the pre-sign (block-only) state;
 // pass the signed ExtendedCommit after signing to record the post-sign state.
-func (bs *BlockStore) SavePendingProposal(block *types.Block, commit *types.ExtendedCommit) error {
+func (bs *BlockStore) SavePendingProposal(block *types.Block, commit *types.ExtendedCommit) {
 	blockProto, err := block.ToProto()
 	if err != nil {
-		return fmt.Errorf("failed to convert block to proto: %w", err)
+		panic(fmt.Sprintf("failed to convert block to proto: %v", err))
 	}
 	pb := &seqproto.ProposedBlock{Block: blockProto}
 	if commit != nil {
@@ -784,9 +784,11 @@ func (bs *BlockStore) SavePendingProposal(block *types.Block, commit *types.Exte
 	}
 	bz, err := proto.Marshal(pb)
 	if err != nil {
-		return fmt.Errorf("failed to marshal pending proposal: %w", err)
+		panic(fmt.Sprintf("failed to marshal pending proposal: %v", err))
 	}
-	return bs.db.SetSync(pendingProposalKey, bz)
+	if err := bs.db.SetSync(pendingProposalKey, bz); err != nil {
+		panic(fmt.Sprintf("failed to save pending proposal: %v", err))
+	}
 }
 
 // LoadPendingProposal loads the persisted pending proposal, if any.

--- a/store/store.go
+++ b/store/store.go
@@ -823,7 +823,7 @@ func (bs *BlockStore) LoadPendingProposal() (block *types.Block, commit *types.E
 
 // DeletePendingProposal removes the persisted pending proposal.
 func (bs *BlockStore) DeletePendingProposal() error {
-	return bs.db.Delete(pendingProposalKey)
+	return bs.db.DeleteSync(pendingProposalKey)
 }
 
 //-----------------------------------------------------------------------------

--- a/store/store.go
+++ b/store/store.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cometbft/cometbft/evidence"
 	cmtsync "github.com/cometbft/cometbft/libs/sync"
+	seqproto "github.com/cometbft/cometbft/proto/tendermint/sequencing"
 	cmtstore "github.com/cometbft/cometbft/proto/tendermint/store"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	sm "github.com/cometbft/cometbft/state"
@@ -761,6 +762,63 @@ func (bs *BlockStore) saveValidatorSetBatch(valSet *types.ValidatorSet, batch db
 		return fmt.Errorf("unable to marshal validator set: %w", err)
 	}
 	return batch.Set(calcValidatorSetKey(valSetHash), valSetBytes)
+}
+
+// SEQUENCING: pending proposal storage for crash-safe block production.
+// The sequencer saves the proposed block before and after signing so that
+// on restart it can recover without re-creating a potentially conflicting block.
+
+var pendingProposalKey = []byte("PP")
+
+// SavePendingProposal persists a pending sequencer proposal.
+// Pass a nil commit to record the pre-sign (block-only) state;
+// pass the signed ExtendedCommit after signing to record the post-sign state.
+func (bs *BlockStore) SavePendingProposal(block *types.Block, commit *types.ExtendedCommit) error {
+	blockProto, err := block.ToProto()
+	if err != nil {
+		return fmt.Errorf("failed to convert block to proto: %w", err)
+	}
+	pb := &seqproto.ProposedBlock{Block: blockProto}
+	if commit != nil {
+		pb.Commit = commit.ToProto()
+	}
+	bz, err := proto.Marshal(pb)
+	if err != nil {
+		return fmt.Errorf("failed to marshal pending proposal: %w", err)
+	}
+	return bs.db.Set(pendingProposalKey, bz)
+}
+
+// LoadPendingProposal loads the persisted pending proposal, if any.
+// commit is nil when the block was saved before signing.
+func (bs *BlockStore) LoadPendingProposal() (block *types.Block, commit *types.ExtendedCommit) {
+	bz, err := bs.db.Get(pendingProposalKey)
+	if err != nil || len(bz) == 0 {
+		return nil, nil
+	}
+	pb := &seqproto.ProposedBlock{}
+	if err := proto.Unmarshal(bz, pb); err != nil {
+		return nil, nil
+	}
+	if pb.Block == nil {
+		return nil, nil
+	}
+	block, err = types.BlockFromProto(pb.Block)
+	if err != nil {
+		return nil, nil
+	}
+	if pb.Commit != nil {
+		commit, err = types.ExtendedCommitFromProto(pb.Commit)
+		if err != nil {
+			return nil, nil
+		}
+	}
+	return block, commit
+}
+
+// DeletePendingProposal removes the persisted pending proposal.
+func (bs *BlockStore) DeletePendingProposal() error {
+	return bs.db.Delete(pendingProposalKey)
 }
 
 //-----------------------------------------------------------------------------

--- a/store/store.go
+++ b/store/store.go
@@ -786,14 +786,17 @@ func (bs *BlockStore) SavePendingProposal(block *types.Block, commit *types.Exte
 	if err != nil {
 		return fmt.Errorf("failed to marshal pending proposal: %w", err)
 	}
-	return bs.db.Set(pendingProposalKey, bz)
+	return bs.db.SetSync(pendingProposalKey, bz)
 }
 
 // LoadPendingProposal loads the persisted pending proposal, if any.
 // commit is nil when the block was saved before signing.
 func (bs *BlockStore) LoadPendingProposal() (block *types.Block, commit *types.ExtendedCommit) {
 	bz, err := bs.db.Get(pendingProposalKey)
-	if err != nil || len(bz) == 0 {
+	if err != nil {
+		panic(fmt.Sprintf("failed to load pending proposal: %v", err))
+	}
+	if len(bz) == 0 {
 		return nil, nil
 	}
 	pb := &seqproto.ProposedBlock{}

--- a/store/store.go
+++ b/store/store.go
@@ -803,19 +803,19 @@ func (bs *BlockStore) LoadPendingProposal() (block *types.Block, commit *types.E
 	}
 	pb := &seqproto.ProposedBlock{}
 	if err := proto.Unmarshal(bz, pb); err != nil {
-		return nil, nil
+		panic(fmt.Sprintf("failed to unmarshal pending proposal: %v", err))
 	}
 	if pb.Block == nil {
-		return nil, nil
+		panic("pending proposal is missing block payload")
 	}
 	block, err = types.BlockFromProto(pb.Block)
 	if err != nil {
-		return nil, nil
+		panic(fmt.Sprintf("failed to decode pending proposal block: %v", err))
 	}
 	if pb.Commit != nil {
 		commit, err = types.ExtendedCommitFromProto(pb.Commit)
 		if err != nil {
-			return nil, nil
+			panic(fmt.Sprintf("failed to decode pending proposal commit: %v", err))
 		}
 	}
 	return block, commit


### PR DESCRIPTION
## Summary

- The sequencer could propose a block, sign it, and broadcast it to peers — but if the node crashed before `blockProcessor` applied the block to state, the block was never persisted. On restart the sequencer would create a different block at the same height, causing a fork with peers that had already applied the original.
- The previous recovery mechanism (`lastProposedBlock` applied in `Wait()`) only worked on clean shutdown and could silently fail if the ABCI proxy was already torn down.
- Replace with a write-ahead approach: persist the pending proposal to the block store before signing and again after signing, so recovery is possible regardless of when the crash occurred.

## Changes

**`store/store.go`**
- `SavePendingProposal(block, commit)` — called before signing (`commit=nil`) and again after signing
- `LoadPendingProposal()` — loads the persisted block and optional commit on startup
- `DeletePendingProposal()` — called immediately after `SaveBlockWithValidatorSet` once the block is durable

**`sequencing/engine/handlers.go` — `proposeBlock()`**
- On entry, check `LoadPendingProposal` for the current height:
  - **Signed**: skip block creation and signing, dispatch directly
  - **Unsigned**: reuse stored block, request signature again (KMS rejection logged and skipped as before)
  - **None**: create new block → save pre-sign → sign → save post-sign
- `applyProposedBlock()`: call `DeletePendingProposal` right after `SaveBlockWithValidatorSet`

**`sequencing/engine/engine.go`**
- Remove `lastProposedBlock` field
- Simplify `Wait()` to just drain `<-e.done`; apply-on-shutdown logic is no longer needed

## Test plan

- [ ] Existing sequencing engine tests pass (`go test ./sequencing/...`)
- [ ] Crash before signing: on restart the same block content is re-signed and proposed
- [ ] Crash after signing: on restart the stored signature is reused and broadcast directly
- [ ] Normal shutdown: pending proposal is cleaned up after `SaveBlockWithValidatorSet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Crash-safe recovery for pending block proposals: proposal state (pre- and post-sign) is persisted so proposals survive restarts.

* **Improvements**
  * Shutdown simplified to no longer try applying pending proposals during termination.
  * Proposal flow refined to persist pre-sign and post-sign states, resume signed or unsigned proposals on restart, and ensure broadcasts occur after proposal resolution.

* **Bug Fixes**
  * Pending proposals are removed once a proposal is durably applied.

* **Tests**
  * Added tests for proposal persistence, signed/unsigned recovery, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->