### PR TITLE
feat(mempool): add ttl gossip history to guard outbound flow

### DIFF
--- a/mempool/app_events_test.go
+++ b/mempool/app_events_test.go
@@ -190,6 +190,48 @@ func TestAppEventLoop_EventTxRemoved_RemovesFromKnownTxs(t *testing.T) {
 	require.True(t, ok, "tx should be removed from knownTxs after EventTxRemoved")
 }
 
+func TestAppEventLoop_EventTxRemoved_PreservesGossipHistory(t *testing.T) {
+	config := cfg.TestConfig()
+	reactors, switches := makeAndConnectReactors(config, 1)
+	defer func() {
+		for _, s := range switches {
+			_ = s.Stop()
+		}
+	}()
+
+	r := reactors[0]
+	tx := types.Tx("evict-readmit-tx")
+	txKey := tx.Key()
+	now := time.Now()
+
+	r.insertedTxsMtx.Lock()
+	r.insertedTxs[txKey] = tx
+	r.recordGossipLocked(txKey, now, r.mempool.Height())
+	r.insertedTxsMtx.Unlock()
+
+	r.mempool.AppEventCh() <- AppMempoolEvent{
+		Type:  EventTxRemoved,
+		TxKey: txKey,
+	}
+
+	ok := waitForCondition(2*time.Second, func() bool {
+		r.insertedTxsMtx.Lock()
+		_, inserted := r.insertedTxs[txKey]
+		_, history := r.gossipHistory.Get(txKey)
+		r.insertedTxsMtx.Unlock()
+		return !inserted && history && r.mempool.isAdmissionCoolingDown(txKey)
+	})
+	require.True(t, ok, "tx removal should preserve gossip history and start admission cooldown")
+
+	r.insertedTxsMtx.Lock()
+	shouldGossipNow := r.shouldGossipNowLocked(txKey, now.Add(time.Second), r.mempool.Height())
+	shouldGossipLater := r.shouldGossipNowLocked(txKey, now.Add(2*regossipBaseInterval+time.Second), r.mempool.Height())
+	r.insertedTxsMtx.Unlock()
+
+	require.False(t, shouldGossipNow, "readmitted tx should stay under existing backoff")
+	require.True(t, shouldGossipLater, "tx should become gossipable after existing backoff elapses")
+}
+
 func TestAppEventLoop_EventTxQueued_GossipsToPeers(t *testing.T) {
 	config := cfg.TestConfig()
 	const N = 2
@@ -341,12 +383,13 @@ func TestGossipLoop_TimeBased(t *testing.T) {
 	txKey := types.Tx(tx).Key()
 
 	reactors[0].insertedTxsMtx.Lock()
-	reactors[0].insertedTxs[txKey] = &regossipEntry{
-		tx:               tx,
+	reactors[0].insertedTxs[txKey] = tx
+	reactors[0].gossipHistory.Add(txKey, &gossipHistoryEntry{
 		lastGossipTime:   time.Now().Add(-regossipBaseInterval - time.Second),
 		lastGossipHeight: reactors[0].mempool.Height(),
 		attempts:         0,
-	}
+		expiry:           time.Now().Add(gossipHistoryTTL),
+	})
 	reactors[0].insertedTxsMtx.Unlock()
 
 	// wait for reactor[1] to receive the tx via regossip
@@ -376,12 +419,13 @@ func TestRegossipLoop_HeightBased(t *testing.T) {
 
 	// inject a tx with recent lastGossipTime but old lastGossipHeight
 	reactors[0].insertedTxsMtx.Lock()
-	reactors[0].insertedTxs[txKey] = &regossipEntry{
-		tx:               tx,
+	reactors[0].insertedTxs[txKey] = tx
+	reactors[0].gossipHistory.Add(txKey, &gossipHistoryEntry{
 		lastGossipTime:   time.Now().Add(time.Hour), // far in the future, time won't trigger
 		lastGossipHeight: 0,                         // old height, height condition will trigger
 		attempts:         0,
-	}
+		expiry:           time.Now().Add(gossipHistoryTTL),
+	})
 	reactors[0].insertedTxsMtx.Unlock()
 
 	// advance height past the height interval
@@ -411,11 +455,7 @@ func TestRegossipLoop_CleansCommittedTxs(t *testing.T) {
 
 	// add tx to insertedTxs
 	reactors[0].insertedTxsMtx.Lock()
-	reactors[0].insertedTxs[txKey] = &regossipEntry{
-		tx:               tx,
-		lastGossipTime:   time.Now(),
-		lastGossipHeight: 0,
-	}
+	reactors[0].insertedTxs[txKey] = tx
 	reactors[0].insertedTxsMtx.Unlock()
 
 	mp := reactors[0].mempool
@@ -449,17 +489,18 @@ func TestRegossipLoop_AttemptsIncrement(t *testing.T) {
 
 	// inject tx with expired backoff so it triggers immediately
 	reactors[0].insertedTxsMtx.Lock()
-	reactors[0].insertedTxs[txKey] = &regossipEntry{
-		tx:               tx,
+	reactors[0].insertedTxs[txKey] = tx
+	reactors[0].gossipHistory.Add(txKey, &gossipHistoryEntry{
 		lastGossipTime:   time.Now().Add(-regossipBaseInterval - time.Second),
 		lastGossipHeight: 0,
 		attempts:         0,
-	}
+		expiry:           time.Now().Add(gossipHistoryTTL),
+	})
 	reactors[0].insertedTxsMtx.Unlock()
 
 	ok := waitForCondition(5*time.Second, func() bool {
 		reactors[0].insertedTxsMtx.Lock()
-		entry, exists := reactors[0].insertedTxs[txKey]
+		entry, exists := reactors[0].gossipHistory.Get(txKey)
 		var attempts int
 		if exists {
 			attempts = entry.attempts
@@ -468,6 +509,37 @@ func TestRegossipLoop_AttemptsIncrement(t *testing.T) {
 		return exists && attempts >= 1
 	})
 	require.True(t, ok, "attempts should be incremented after regossip")
+}
+
+func TestGossipHistory_BoundsEntriesByCacheSize(t *testing.T) {
+	config := cfg.TestConfig()
+	config.Mempool.CacheSize = 2
+	reactors, switches := makeAndConnectReactors(config, 1)
+	defer func() {
+		for _, s := range switches {
+			_ = s.Stop()
+		}
+	}()
+
+	tx1 := types.Tx("gossip-history-1").Key()
+	tx2 := types.Tx("gossip-history-2").Key()
+	tx3 := types.Tx("gossip-history-3").Key()
+
+	reactors[0].insertedTxsMtx.Lock()
+	now := time.Now()
+	reactors[0].recordGossipLocked(tx1, now, 1)
+	reactors[0].recordGossipLocked(tx2, now, 1)
+	reactors[0].recordGossipLocked(tx3, now, 1)
+	_, hasTx1 := reactors[0].gossipHistory.Get(tx1)
+	_, hasTx2 := reactors[0].gossipHistory.Get(tx2)
+	_, hasTx3 := reactors[0].gossipHistory.Get(tx3)
+	historyLen := reactors[0].gossipHistory.Len()
+	reactors[0].insertedTxsMtx.Unlock()
+
+	require.False(t, hasTx1, "oldest gossip history should be evicted")
+	require.True(t, hasTx2)
+	require.True(t, hasTx3)
+	require.LessOrEqual(t, historyLen, config.Mempool.CacheSize)
 }
 
 func TestEventTxInserted_DoesNotGossip(t *testing.T) {

--- a/mempool/proxy_mempool.go
+++ b/mempool/proxy_mempool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/config"
@@ -11,7 +12,30 @@ import (
 	cmtsync "github.com/cometbft/cometbft/libs/sync"
 	"github.com/cometbft/cometbft/proxy"
 	"github.com/cometbft/cometbft/types"
+	lru "github.com/hashicorp/golang-lru/v2"
 )
+
+const (
+	// admissionCooldownBaseTTL is the first local reject window after the app
+	// mempool removes a tx. It should be long enough to absorb immediate peer
+	// regossip, but short enough that a tx which later becomes valid is not
+	// hidden from this node for long.
+	admissionCooldownBaseTTL = 5 * time.Second
+
+	// admissionCooldownMaxTTL caps the adaptive reject window for a single tx
+	// hash. Repeated removals can extend the cooldown up to this bound.
+	admissionCooldownMaxTTL = 5 * time.Minute
+
+	// admissionCooldownMaxRemovals bounds the left shift used for exponential
+	// TTL growth even though admissionCooldownMaxTTL is the effective duration
+	// cap. Keeping both caps avoids overflow if this constant changes later.
+	admissionCooldownMaxRemovals = 16
+)
+
+type admissionCooldownEntry struct {
+	removals int
+	expiry   time.Time
+}
 
 // ProxyMempool implements the Mempool interface as a thin passthrough.
 // By using this ProxyMempool the CometBFT becomes a gossip layer while the application owns the real mempool.
@@ -42,6 +66,15 @@ type ProxyMempool struct {
 	// LRU cache of committed tx hashes, populated during Update so that gossip of committed txs is rejected locally
 	includedTxCache *LRUTxCache
 
+	// admissionCooldown rejects exact tx hashes that were recently removed from
+	// the application mempool. This prevents an evict-readmit loop where peers
+	// immediately regossip the same bytes after the app has decided to remove
+	// them. It is deliberately separate from includedTxCache: includedTxCache is
+	// for committed txs, while admissionCooldown is a short local backoff for
+	// txs the app mempool just dropped.
+	admissionCooldownMtx sync.Mutex
+	admissionCooldown    *lru.Cache[types.TxKey, *admissionCooldownEntry]
+
 	logger  log.Logger
 	metrics *Metrics
 }
@@ -68,6 +101,7 @@ func NewProxyMempool(
 		logger:          log.NewNopLogger(),
 		metrics:         NopMetrics(),
 	}
+	mp.admissionCooldown = newAdmissionCooldown(cacheSize)
 	mp.height.Store(height)
 
 	// no-op callback so the local client doesn't panic
@@ -78,6 +112,17 @@ func NewProxyMempool(
 	}
 
 	return mp
+}
+
+func newAdmissionCooldown(cacheSize int) *lru.Cache[types.TxKey, *admissionCooldownEntry] {
+	if cacheSize <= 0 {
+		cacheSize = 10000
+	}
+	cache, err := lru.New[types.TxKey, *admissionCooldownEntry](cacheSize)
+	if err != nil {
+		panic(err)
+	}
+	return cache
 }
 
 // WithProxyMempoolMetrics sets the metrics on the ProxyMempool.
@@ -119,6 +164,14 @@ func (mp *ProxyMempool) CheckTx(
 	}
 
 	if mp.includedTxCache.Has(tx) {
+		return ErrTxInCache
+	}
+
+	// If the app mempool recently removed these exact bytes, do not call
+	// CheckTx again yet. Returning ErrTxInCache keeps peer-originated retries on
+	// the existing quiet duplicate path and prevents a local readmit/regossip
+	// cycle while the cooldown is active.
+	if mp.isAdmissionCoolingDown(txKey) {
 		return ErrTxInCache
 	}
 
@@ -165,6 +218,50 @@ func (mp *ProxyMempool) CheckTx(
 	})
 
 	return nil
+}
+
+// AddAdmissionCooldown records that the application mempool removed this tx
+// hash and asks CheckTx to reject the same bytes locally for a short period.
+//
+// The cooldown is adaptive per hash: one removal gets the base TTL, and
+// repeated removals before the previous cooldown expires extend the TTL
+// exponentially up to a cap. The LRU size bound keeps both active cooldowns and
+// repeated-removal counters bounded by the node's normal tx cache size.
+func (mp *ProxyMempool) AddAdmissionCooldown(txKey types.TxKey) {
+	now := time.Now()
+
+	mp.admissionCooldownMtx.Lock()
+	defer mp.admissionCooldownMtx.Unlock()
+
+	entry, ok := mp.admissionCooldown.Get(txKey)
+	if !ok {
+		entry = &admissionCooldownEntry{}
+	} else if !entry.expiry.After(now) {
+		entry.removals = 0
+	}
+
+	entry.removals++
+
+	attempts := min(entry.removals-1, admissionCooldownMaxRemovals)
+	ttl := min(admissionCooldownBaseTTL<<attempts, admissionCooldownMaxTTL)
+	entry.expiry = now.Add(ttl)
+	mp.admissionCooldown.Add(txKey, entry)
+}
+
+func (mp *ProxyMempool) isAdmissionCoolingDown(txKey types.TxKey) bool {
+	mp.admissionCooldownMtx.Lock()
+	defer mp.admissionCooldownMtx.Unlock()
+
+	entry, ok := mp.admissionCooldown.Get(txKey)
+	if !ok {
+		return false
+	}
+	if entry.expiry.After(time.Now()) {
+		return true
+	}
+
+	mp.admissionCooldown.Remove(txKey)
+	return false
 }
 
 // RemoveTxByKey removes a transaction from the knownTxs cache.
@@ -250,6 +347,9 @@ func (mp *ProxyMempool) Flush() {
 		mp.inCheckTxs.Delete(key)
 		return true
 	})
+	mp.admissionCooldownMtx.Lock()
+	mp.admissionCooldown.Purge()
+	mp.admissionCooldownMtx.Unlock()
 }
 
 // TxsAvailable returns a channel that fires once per height when transactions are available in the mempool.

--- a/mempool/proxy_mempool.go
+++ b/mempool/proxy_mempool.go
@@ -224,7 +224,7 @@ func (mp *ProxyMempool) CheckTx(
 // hash and asks CheckTx to reject the same bytes locally for a short period.
 //
 // The cooldown is adaptive per hash: one removal gets the base TTL, and
-// repeated removals before the previous cooldown expires extend the TTL
+// repeated removals while the tx remains in the LRU extend the TTL
 // exponentially up to a cap. The LRU size bound keeps both active cooldowns and
 // repeated-removal counters bounded by the node's normal tx cache size.
 func (mp *ProxyMempool) AddAdmissionCooldown(txKey types.TxKey) {
@@ -236,8 +236,6 @@ func (mp *ProxyMempool) AddAdmissionCooldown(txKey types.TxKey) {
 	entry, ok := mp.admissionCooldown.Get(txKey)
 	if !ok {
 		entry = &admissionCooldownEntry{}
-	} else if !entry.expiry.After(now) {
-		entry.removals = 0
 	}
 
 	entry.removals++
@@ -260,7 +258,6 @@ func (mp *ProxyMempool) isAdmissionCoolingDown(txKey types.TxKey) bool {
 		return true
 	}
 
-	mp.admissionCooldown.Remove(txKey)
 	return false
 }
 

--- a/mempool/proxy_mempool_test.go
+++ b/mempool/proxy_mempool_test.go
@@ -149,6 +149,104 @@ func TestProxyMempool_CheckTx_IncludedTxCache(t *testing.T) {
 	require.ErrorIs(t, err, ErrTxInCache)
 }
 
+func TestProxyMempool_CheckTx_AdmissionCooldown(t *testing.T) {
+	t.Run("cooldown rejects before app CheckTx", func(t *testing.T) {
+		conn := newMockAppConn(t)
+		mp := NewProxyMempool(newTestConfig(), conn, 0)
+		mp.SetLogger(log.NewNopLogger())
+
+		tx := types.Tx("cooldown-tx")
+		mp.AddAdmissionCooldown(tx.Key())
+
+		err := mp.CheckTx(tx, nil, TxInfo{})
+		require.ErrorIs(t, err, ErrTxInCache)
+	})
+
+	t.Run("expired cooldown lets CheckTx proceed", func(t *testing.T) {
+		conn := newMockAppConn(t)
+		setupCheckTxAsyncOK(conn)
+
+		mp := NewProxyMempool(newTestConfig(), conn, 0)
+		mp.SetLogger(log.NewNopLogger())
+
+		tx := types.Tx("expired-cooldown-tx")
+		txKey := tx.Key()
+		mp.admissionCooldownMtx.Lock()
+		mp.admissionCooldown.Add(txKey, &admissionCooldownEntry{
+			removals: 1,
+			expiry:   time.Now().Add(-time.Second),
+		})
+		mp.admissionCooldownMtx.Unlock()
+
+		err := mp.CheckTx(tx, nil, TxInfo{})
+		require.NoError(t, err)
+	})
+}
+
+func TestProxyMempool_AddAdmissionCooldown_ExtendsRepeatedRemovals(t *testing.T) {
+	conn := newMockAppConn(t)
+	mp := NewProxyMempool(newTestConfig(), conn, 0)
+	mp.SetLogger(log.NewNopLogger())
+
+	txKey := types.Tx("repeated-removal-tx").Key()
+
+	mp.AddAdmissionCooldown(txKey)
+	mp.admissionCooldownMtx.Lock()
+	firstEntry, firstOK := mp.admissionCooldown.Get(txKey)
+	firstExpiry := time.Time{}
+	firstRemovals := 0
+	if firstOK {
+		firstExpiry = firstEntry.expiry
+		firstRemovals = firstEntry.removals
+	}
+	mp.admissionCooldownMtx.Unlock()
+
+	mp.AddAdmissionCooldown(txKey)
+	mp.admissionCooldownMtx.Lock()
+	secondEntry, secondOK := mp.admissionCooldown.Get(txKey)
+	secondExpiry := time.Time{}
+	secondRemovals := 0
+	if secondOK {
+		secondExpiry = secondEntry.expiry
+		secondRemovals = secondEntry.removals
+	}
+	mp.admissionCooldownMtx.Unlock()
+
+	require.True(t, firstOK)
+	require.True(t, secondOK)
+	require.Equal(t, 1, firstRemovals)
+	require.Equal(t, 2, secondRemovals)
+	require.True(t, secondExpiry.After(firstExpiry), "repeated removals should extend cooldown")
+}
+
+func TestProxyMempool_AddAdmissionCooldown_BoundsCacheByCacheSize(t *testing.T) {
+	conn := newMockAppConn(t)
+	cfg := newTestConfig()
+	cfg.CacheSize = 2
+	mp := NewProxyMempool(cfg, conn, 0)
+	mp.SetLogger(log.NewNopLogger())
+
+	tx1 := types.Tx("cooldown-1").Key()
+	tx2 := types.Tx("cooldown-2").Key()
+	tx3 := types.Tx("cooldown-3").Key()
+
+	mp.AddAdmissionCooldown(tx1)
+	mp.AddAdmissionCooldown(tx2)
+	mp.AddAdmissionCooldown(tx3)
+
+	mp.admissionCooldownMtx.Lock()
+	_, hasTx1Cooldown := mp.admissionCooldown.Get(tx1)
+	_, hasTx2Cooldown := mp.admissionCooldown.Get(tx2)
+	_, hasTx3Cooldown := mp.admissionCooldown.Get(tx3)
+	cacheLen := mp.admissionCooldown.Len()
+	mp.admissionCooldownMtx.Unlock()
+
+	require.False(t, hasTx1Cooldown, "oldest cooldown should be evicted")
+	require.True(t, hasTx2Cooldown)
+	require.True(t, hasTx3Cooldown)
+	require.LessOrEqual(t, cacheLen, cfg.CacheSize)
+}
+
 func TestProxyMempool_CheckTx_EventTxQueued(t *testing.T) {
 	conn := newMockAppConn(t)
 	setupCheckTxAsyncOK(conn)

--- a/mempool/proxy_mempool_test.go
+++ b/mempool/proxy_mempool_test.go
@@ -219,6 +219,36 @@ func TestProxyMempool_AddAdmissionCooldown_ExtendsRepeatedRemovals(t *testing.T)
 	require.True(t, secondExpiry.After(firstExpiry), "repeated removals should extend cooldown")
 }
 
+func TestProxyMempool_AddAdmissionCooldown_ExtendsAfterExpiredCooldown(t *testing.T) {
+	conn := newMockAppConn(t)
+	mp := NewProxyMempool(newTestConfig(), conn, 0)
+	mp.SetLogger(log.NewNopLogger())
+
+	txKey := types.Tx("expired-repeated-removal-tx").Key()
+
+	mp.admissionCooldownMtx.Lock()
+	mp.admissionCooldown.Add(txKey, &admissionCooldownEntry{
+		removals: 1,
+		expiry:   time.Now().Add(-time.Second),
+	})
+	mp.admissionCooldownMtx.Unlock()
+
+	require.False(t, mp.isAdmissionCoolingDown(txKey))
+
+	mp.AddAdmissionCooldown(txKey)
+
+	mp.admissionCooldownMtx.Lock()
+	entry, ok := mp.admissionCooldown.Get(txKey)
+	removals := 0
+	if ok {
+		removals = entry.removals
+	}
+	mp.admissionCooldownMtx.Unlock()
+
+	require.True(t, ok)
+	require.Equal(t, 2, removals)
+}
+
 func TestProxyMempool_AddAdmissionCooldown_BoundsCacheByCacheSize(t *testing.T) {
 	conn := newMockAppConn(t)
 	cfg := newTestConfig()

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cometbft/cometbft/p2p"
 	protomem "github.com/cometbft/cometbft/proto/tendermint/mempool"
 	"github.com/cometbft/cometbft/types"
+	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 const (
@@ -26,15 +27,9 @@ const (
 	gossipHistoryTTL = 5 * time.Minute
 )
 
-// regossipEntry tracks tx in the regossip set. Per-tx outbound gossip
-// state (attempts, last time/height) lives in gossipHistory, so it survives
-// evict-readmit cycles and continues to grow exponential backoff.
-type regossipEntry struct {
-	tx types.Tx
-}
-
 // gossipHistoryEntry records outbound gossip state for a tx hash, independent
-// of whether the tx is currently in the active mempool. Cleared by TTL.
+// of whether the tx is currently in the active mempool. The LRU bounds memory
+// growth while expiry resets backoff for txs that have been quiet long enough.
 type gossipHistoryEntry struct {
 	lastGossipTime   time.Time
 	lastGossipHeight int64
@@ -52,25 +47,36 @@ type Reactor struct {
 
 	// insertedTxs is the regossip set of txs currently in the active mempool.
 	insertedTxsMtx cmtsync.Mutex
-	insertedTxs    map[types.TxKey]*regossipEntry
+	insertedTxs    map[types.TxKey]types.Tx
 
 	// gossipHistory persists per-hash outbound gossip state across evict-readmit
 	// cycles, so exponential backoff continues to grow regardless of admission.
-	gossipHistory map[types.TxKey]*gossipHistoryEntry
+	gossipHistory *lru.Cache[types.TxKey, *gossipHistoryEntry]
 }
 
 // NewReactor returns a new Reactor with the given config and mempool.
 func NewReactor(config *cfg.MempoolConfig, mempool *ProxyMempool) *Reactor {
 	memR := &Reactor{
-		config:        config,
-		mempool:       mempool,
-		ids:           newMempoolIDs(),
-		insertedTxs:   make(map[types.TxKey]*regossipEntry),
-		gossipHistory: make(map[types.TxKey]*gossipHistoryEntry),
+		config:      config,
+		mempool:     mempool,
+		ids:         newMempoolIDs(),
+		insertedTxs: make(map[types.TxKey]types.Tx),
 	}
+	memR.gossipHistory = newGossipHistory(config.CacheSize)
 	memR.BaseReactor = *p2p.NewBaseReactor("Mempool", memR)
 
 	return memR
+}
+
+func newGossipHistory(cacheSize int) *lru.Cache[types.TxKey, *gossipHistoryEntry] {
+	if cacheSize <= 0 {
+		cacheSize = 10000
+	}
+	cache, err := lru.New[types.TxKey, *gossipHistoryEntry](cacheSize)
+	if err != nil {
+		panic(err)
+	}
+	return cache
 }
 
 // InitPeer implements Reactor by creating a state for the peer.
@@ -190,7 +196,7 @@ func (memR *Reactor) appEventLoop() {
 
 			case EventTxInserted:
 				memR.insertedTxsMtx.Lock()
-				memR.insertedTxs[ev.TxKey] = &regossipEntry{tx: ev.Tx}
+				memR.insertedTxs[ev.TxKey] = ev.Tx
 				memR.mempool.SetHasValidTxs(true)
 				memR.mempool.NotifyTxsAvailable()
 				memR.insertedTxsMtx.Unlock()
@@ -204,6 +210,7 @@ func (memR *Reactor) appEventLoop() {
 				memR.insertedTxsMtx.Unlock()
 
 				memR.mempool.RemoveTxByKey(ev.TxKey)
+				memR.mempool.AddAdmissionCooldown(ev.TxKey)
 			}
 
 		case <-memR.Quit():
@@ -230,19 +237,13 @@ func (memR *Reactor) regossipLoop() {
 			var toGossip []types.Tx
 
 			memR.insertedTxsMtx.Lock()
-			// sweep expired gossipHistory entries
-			for k, entry := range memR.gossipHistory {
-				if !entry.expiry.After(now) {
-					delete(memR.gossipHistory, k)
-				}
-			}
-			for k, entry := range memR.insertedTxs {
-				if memR.mempool.IsIncludedTx(entry.tx) {
+			for k, tx := range memR.insertedTxs {
+				if memR.mempool.IsIncludedTx(tx) {
 					delete(memR.insertedTxs, k)
 					continue
 				}
 				if memR.shouldGossipNowLocked(k, now, curHeight) {
-					toGossip = append(toGossip, entry.tx)
+					toGossip = append(toGossip, tx)
 					memR.recordGossipLocked(k, now, curHeight)
 				}
 			}
@@ -262,8 +263,12 @@ func (memR *Reactor) regossipLoop() {
 // the last gossip of this tx to fire another broadcast under exponential backoff.
 // Caller must hold insertedTxsMtx.
 func (memR *Reactor) shouldGossipNowLocked(key types.TxKey, now time.Time, curHeight int64) bool {
-	entry, ok := memR.gossipHistory[key]
+	entry, ok := memR.gossipHistory.Get(key)
 	if !ok {
+		return true
+	}
+	if !entry.expiry.After(now) {
+		memR.gossipHistory.Remove(key)
 		return true
 	}
 
@@ -284,16 +289,16 @@ func (memR *Reactor) shouldGossipNowLocked(key types.TxKey, now time.Time, curHe
 // recordGossipLocked updates gossip history after a successful broadcast.
 // Caller must hold insertedTxsMtx.
 func (memR *Reactor) recordGossipLocked(key types.TxKey, now time.Time, curHeight int64) {
-	entry, ok := memR.gossipHistory[key]
+	entry, ok := memR.gossipHistory.Get(key)
 	if !ok {
 		entry = &gossipHistoryEntry{}
-		memR.gossipHistory[key] = entry
 	}
 
 	entry.lastGossipTime = now
 	entry.lastGossipHeight = curHeight
 	entry.attempts++
 	entry.expiry = now.Add(gossipHistoryTTL)
+	memR.gossipHistory.Add(key, entry)
 }
 
 // gossipTxToPeers sends a tx to all connected peers, skipping the excluding peer.

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -22,14 +22,24 @@ const (
 
 	regossipHeightInterval    int64 = 3
 	regossipMaxHeightInterval int64 = 100
+
+	gossipHistoryTTL = 5 * time.Minute
 )
 
-// regossipEntry tracks a tx in the regossip set with per-tx back-off state.
+// regossipEntry tracks tx in the regossip set. Per-tx outbound gossip
+// state (attempts, last time/height) lives in gossipHistory, so it survives
+// evict-readmit cycles and continues to grow exponential backoff.
 type regossipEntry struct {
-	tx               types.Tx
+	tx types.Tx
+}
+
+// gossipHistoryEntry records outbound gossip state for a tx hash, independent
+// of whether the tx is currently in the active mempool. Cleared by TTL.
+type gossipHistoryEntry struct {
 	lastGossipTime   time.Time
 	lastGossipHeight int64
 	attempts         int
+	expiry           time.Time
 }
 
 // Reactor handles mempool tx broadcasting amongst peers.
@@ -40,18 +50,23 @@ type Reactor struct {
 	mempool *ProxyMempool
 	ids     *mempoolIDs
 
-	// insertedTxs is the regossip set of txs promoted to the active mempool.
+	// insertedTxs is the regossip set of txs currently in the active mempool.
 	insertedTxsMtx cmtsync.Mutex
 	insertedTxs    map[types.TxKey]*regossipEntry
+
+	// gossipHistory persists per-hash outbound gossip state across evict-readmit
+	// cycles, so exponential backoff continues to grow regardless of admission.
+	gossipHistory map[types.TxKey]*gossipHistoryEntry
 }
 
 // NewReactor returns a new Reactor with the given config and mempool.
 func NewReactor(config *cfg.MempoolConfig, mempool *ProxyMempool) *Reactor {
 	memR := &Reactor{
-		config:      config,
-		mempool:     mempool,
-		ids:         newMempoolIDs(),
-		insertedTxs: make(map[types.TxKey]*regossipEntry),
+		config:        config,
+		mempool:       mempool,
+		ids:           newMempoolIDs(),
+		insertedTxs:   make(map[types.TxKey]*regossipEntry),
+		gossipHistory: make(map[types.TxKey]*gossipHistoryEntry),
 	}
 	memR.BaseReactor = *p2p.NewBaseReactor("Mempool", memR)
 
@@ -160,16 +175,22 @@ func (memR *Reactor) appEventLoop() {
 			switch ev.Type {
 			case EventTxQueued:
 				if memR.config.Broadcast {
-					memR.gossipTxToPeers(ev.Tx, ev.SenderID)
+					now := time.Now()
+					curHeight := memR.mempool.Height()
+					memR.insertedTxsMtx.Lock()
+					gossip := memR.shouldGossipNowLocked(ev.TxKey, now, curHeight)
+					if gossip {
+						memR.recordGossipLocked(ev.TxKey, now, curHeight)
+					}
+					memR.insertedTxsMtx.Unlock()
+					if gossip {
+						memR.gossipTxToPeers(ev.Tx, ev.SenderID)
+					}
 				}
 
 			case EventTxInserted:
 				memR.insertedTxsMtx.Lock()
-				memR.insertedTxs[ev.TxKey] = &regossipEntry{
-					tx:               ev.Tx,
-					lastGossipTime:   time.Now(),
-					lastGossipHeight: memR.mempool.Height(),
-				}
+				memR.insertedTxs[ev.TxKey] = &regossipEntry{tx: ev.Tx}
 				memR.mempool.SetHasValidTxs(true)
 				memR.mempool.NotifyTxsAvailable()
 				memR.insertedTxsMtx.Unlock()
@@ -209,23 +230,20 @@ func (memR *Reactor) regossipLoop() {
 			var toGossip []types.Tx
 
 			memR.insertedTxsMtx.Lock()
+			// sweep expired gossipHistory entries
+			for k, entry := range memR.gossipHistory {
+				if !entry.expiry.After(now) {
+					delete(memR.gossipHistory, k)
+				}
+			}
 			for k, entry := range memR.insertedTxs {
 				if memR.mempool.IsIncludedTx(entry.tx) {
 					delete(memR.insertedTxs, k)
 					continue
 				}
-
-				backoff := min(regossipBaseInterval<<min(entry.attempts, regossipMaxAttempts), regossipMaxInterval)
-				timeDue := now.Sub(entry.lastGossipTime) >= backoff
-
-				heightBackoff := min(regossipHeightInterval<<min(entry.attempts, regossipMaxAttempts), regossipMaxHeightInterval)
-				heightDue := curHeight >= entry.lastGossipHeight+heightBackoff
-
-				if timeDue || heightDue {
+				if memR.shouldGossipNowLocked(k, now, curHeight) {
 					toGossip = append(toGossip, entry.tx)
-					entry.lastGossipTime = now
-					entry.lastGossipHeight = curHeight
-					entry.attempts++
+					memR.recordGossipLocked(k, now, curHeight)
 				}
 			}
 			memR.insertedTxsMtx.Unlock()
@@ -238,6 +256,44 @@ func (memR *Reactor) regossipLoop() {
 			return
 		}
 	}
+}
+
+// shouldGossipNowLocked returns whether enough time/height has elapsed since
+// the last gossip of this tx to fire another broadcast under exponential backoff.
+// Caller must hold insertedTxsMtx.
+func (memR *Reactor) shouldGossipNowLocked(key types.TxKey, now time.Time, curHeight int64) bool {
+	entry, ok := memR.gossipHistory[key]
+	if !ok {
+		return true
+	}
+
+	attempts := min(entry.attempts, regossipMaxAttempts)
+	backoff := min(regossipBaseInterval<<attempts, regossipMaxInterval)
+	if now.Sub(entry.lastGossipTime) >= backoff {
+		return true
+	}
+
+	heightBackoff := min(regossipHeightInterval<<attempts, regossipMaxHeightInterval)
+	if curHeight >= entry.lastGossipHeight+heightBackoff {
+		return true
+	}
+
+	return false
+}
+
+// recordGossipLocked updates gossip history after a successful broadcast.
+// Caller must hold insertedTxsMtx.
+func (memR *Reactor) recordGossipLocked(key types.TxKey, now time.Time, curHeight int64) {
+	entry, ok := memR.gossipHistory[key]
+	if !ok {
+		entry = &gossipHistoryEntry{}
+		memR.gossipHistory[key] = entry
+	}
+
+	entry.lastGossipTime = now
+	entry.lastGossipHeight = curHeight
+	entry.attempts++
+	entry.expiry = now.Add(gossipHistoryTTL)
 }
 
 // gossipTxToPeers sends a tx to all connected peers, skipping the excluding peer.

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -209,8 +209,8 @@ func (memR *Reactor) appEventLoop() {
 				}
 				memR.insertedTxsMtx.Unlock()
 
-				memR.mempool.RemoveTxByKey(ev.TxKey)
 				memR.mempool.AddAdmissionCooldown(ev.TxKey)
+				memR.mempool.RemoveTxByKey(ev.TxKey)
 			}
 
 		case <-memR.Quit():


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Regossip state moved to a persistent history cache and regossip eligibility/backoff centralized, reducing redundant rebroadcast attempts.
* **Bug Fixes**
  * Local admission-cooldown with adaptive (exponential, bounded) expiry prevents immediate reprocessing and rebroadcasting of recently removed transactions.
* **Tests**
  * Added/updated tests for gossip-history eviction/preservation and admission-cooldown behavior, expiry, and eviction bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->